### PR TITLE
fix(compose): make docker-compose.yml valid for newer Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,10 @@ services:
     volumes:
       - fgc:/fgc/data
     # command: bash -c "node epic-games; node gog; node steam"  # override CLAIM_CMD below instead
-    environment:
+    # To set env vars, uncomment `environment:` below AND at least one entry
+    # (an `environment:` key with only comments under it is null, which newer
+    # Docker Compose rejects with "environment must be a mapping").
+    # environment:
       # - EMAIL=foo@bar.org
       # - NOTIFY='tgram://...'
       # - LOOP=28800 # scheduler interval in seconds (e.g., 28800 = 8 hours); omit to disable scheduler
@@ -30,3 +33,9 @@ services:
       # - MS_PASSWORD=yourpassword # Microsoft account password (defaults to PASSWORD)
       # - MS_OTPKEY=yourotpsecret # Microsoft 2FA TOTP secret (optional)
       # Note: LOGIN_MODE is deprecated — the panel is always running on port 7080.
+
+# Named volume that persists the browser profile (logins), claim DBs, config,
+# and screenshots. Newer Docker Compose requires the top-level declaration;
+# in this project it resolves to the existing `free-games-claimer_fgc` volume.
+volumes:
+  fgc:


### PR DESCRIPTION
Newer Docker Compose versions reject the file as-is on `docker compose build`/`up`:

- The environment: key had only commented-out entries, leaving it a null mapping, which errors with "services.free-games-claimer.environment must be a mapping". Commented out the environment: key itself; the example entries remain as comments and behaviour is unchanged.
- The fgc named volume was referenced by the service but never declared at the top level ("refers to undefined volume fgc"). Added a top-level volumes: block that resolves to the existing free-games-claimer_fgc volume, so the browser profile / data is preserved.