### PR TITLE
fix: add allow="fullscreen" to noVNC iframe in showVnc()

### DIFF
--- a/interactive-login.js
+++ b/interactive-login.js
@@ -7666,6 +7666,7 @@ function showVnc() {
   if (!container.querySelector('iframe')) {
     const iframe = document.createElement('iframe');
     iframe.src = buildNovncUrl();
+    iframe.allow = 'fullscreen';
     container.appendChild(iframe);
   }
 }


### PR DESCRIPTION
## Problem

Clicking the fullscreen button inside the **"Show browser"** panel view fails in all modern browsers:

- **Firefox:** `Fullscreen request denied`
- **Chrome / Brave:** `TypeError: Disallowed by permissions policy`  
  at `HTMLInputElement.toggleFullscreen (ui.js:1225)`

## Root cause

`showVnc()` creates a `<iframe>` dynamically but does not set `allow="fullscreen"`:

```js
const iframe = document.createElement('iframe');
iframe.src = buildNovncUrl();
// missing: iframe.allow = 'fullscreen';
container.appendChild(iframe);
```

Browsers enforce the [Permissions Policy for `fullscreen`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/fullscreen) at the **iframe element level**. Without `allow="fullscreen"` on the `<iframe>`, `requestFullscreen()` is rejected regardless of any HTTP headers on the framed page.

## Fix

One line before `container.appendChild(iframe)`:

```diff
  iframe.src = buildNovncUrl();
+ iframe.allow = 'fullscreen';
  container.appendChild(iframe);
```

## Notes

- The **"Pop out ↗"** button already works correctly because it opens noVNC in a top-level tab.
- This change has no security implications — it only enables fullscreen for the noVNC iframe the user explicitly opened.
- Tested on Firefox 130 and Brave 1.68 (Chromium 127).