### PR TITLE
feat: per-service locale, timezone & browser args for fingerprint coherence

### DIFF
--- a/aliexpress.js
+++ b/aliexpress.js
@@ -3,7 +3,7 @@
 // If you run it standalone on the CLI, it always executes; the activation
 // gate lives in interactive-login.js.
 import { chromium } from 'patchright';
-import { datetime, filenamify, prompt, handleSIGINT, jsonDb, awaitUserCaptchaSolve, getOrCreateFingerprint, log, notify, cleanProfileLocks, localeArgs } from './src/util.js';
+import { datetime, filenamify, prompt, handleSIGINT, jsonDb, awaitUserCaptchaSolve, getOrCreateFingerprint, log, notify, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 import { FingerprintInjector } from 'fingerprint-injector';
@@ -36,7 +36,8 @@ log.status('Fingerprint', _persisted ? 'loaded from cache' : 'fresh (saved for n
 cleanProfileLocks(profileDir);
 const context = await chromium.launchPersistentContext(profileDir, {
   headless: cfg.headless,
-  locale: 'en-US',
+  locale: siteLocale('aliexpress'), // see siteLocale() for the per-site locale policy
+  timezoneId: cfg.timezone_id,
   recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
   recordHar: cfg.record ? { path: `data/record/aliexpress-${filenamify(datetime())}.har` } : undefined,
   handleSIGINT: false,
@@ -49,7 +50,7 @@ const context = await chromium.launchPersistentContext(profileDir, {
   extraHTTPHeaders: {
     'accept-language': headers['accept-language'],
   },
-  args: ['--hide-crash-restore-bubble', ...localeArgs()],
+  args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('aliexpress'))],
 });
 handleSIGINT(context);
 await new FingerprintInjector().attachFingerprintToPlaywright(context, { fingerprint, headers });
@@ -224,7 +225,7 @@ const auth = async url => {
 };
 
 const urls = {
-  coins: 'https://m.aliexpress.com/p/coin-index/index.html',
+  coins: cfg.ae_page_url || 'https://m.aliexpress.com/p/coin-index/index.html', // AE_PAGE_URL override
 };
 
 const pre_auth = {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -56,6 +56,9 @@ for `BASE_PATH`, `PUBLIC_URL`, and `NOVNC_URL`.
 | `HEIGHT` | `1080` | Browser/screen height |
 | `VNC_PASSWORD` | | VNC password. No password by default. |
 | `BROWSER_DIR` | `data/browser` | Browser profile directory |
+| `LANG` | `en-US` | Browser locale from POSIX `LANG` (e.g. `de_DE.UTF-8` → `de-DE`), so the fingerprint matches your IP |
+| `TZ` | | Container timezone (e.g. `America/Sao_Paulo`); also sets the browser `timezoneId` |
+| `<SVC>_PAGE_URL` | (per-service default) | Override a service's base URL (`EG_`, `GOG_`, `STEAM_`, `FAB_`, `HUMBLE_`, `FANATICAL_`, `LENOVO_`, `UBISOFT_`, `AE_PAGE_URL`; Prime uses `PG_BASE_URL`) |
 | `TIMEOUT` | `60` | Timeout in seconds for page actions |
 | `LOGIN_TIMEOUT` | `180` | Timeout in seconds for login |
 | `DEBUG` | `0` | Set to `1` for verbose debug output |

--- a/epic-games.js
+++ b/epic-games.js
@@ -2,7 +2,7 @@ import { chromium } from 'patchright';
 import { authenticator } from 'otplib';
 import path from 'path';
 import { existsSync, writeFileSync } from 'fs';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, closeContextSafely, log, cleanProfileLocks, localeArgs } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, closeContextSafely, log, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 import { getMobileGames } from './src/epic-games-mobile.js';
@@ -11,7 +11,7 @@ import { fetchFGFPosts, filterFor as filterFgfFor, unhandledPlatforms as fgfUnha
 
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'epic-games', ...a);
 
-const URL_CLAIM = 'https://store.epicgames.com/en-US/free-games';
+const URL_CLAIM = cfg.eg_page_url || 'https://store.epicgames.com/en-US/free-games'; // EG_PAGE_URL override
 const URL_LOGIN = 'https://www.epicgames.com/id/login?lang=en-US&noHostRedirect=true&redirectUrl=' + URL_CLAIM;
 const URL_PROMOTIONS = 'https://store-site-backend-static-ipv4.ak.epicgames.com/freeGamesPromotions?locale=en-US';
 
@@ -46,7 +46,8 @@ const context = await chromium.launchPersistentContext(cfg.dir.browser, {
   // channel: 'chrome', // recommended, but `npx patchright install chrome` clashes with system Chrome - https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-nodejs#best-practice----use-chrome-without-fingerprint-injection
   headless: false, // don't use cfg.headless headless here since SHOW=0 will lead to captcha
   viewport: { width: cfg.width, height: cfg.height },
-  locale: 'en-US', // ignore OS locale to be sure to have english text for locators
+  locale: siteLocale('epic-games'), // see siteLocale() for the per-site locale policy
+  timezoneId: cfg.timezone_id,
   recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated; without size, video would be scaled down to fit 800x800
   recordHar: cfg.record ? { path: `data/record/eg-${filenamify(datetime())}.har` } : undefined, // will record a HAR file with network requests and responses; can be imported in Chrome devtools
   handleSIGINT: false, // have to handle ourselves and call context.close(), otherwise recordings from above won't be saved
@@ -55,7 +56,7 @@ const context = await chromium.launchPersistentContext(cfg.dir.browser, {
     '--hide-crash-restore-bubble',
     '--ignore-gpu-blocklist', // required for OpenGL: Disabled -> Enabled & WebGL: Software only -> Hardware accelerated
     '--enable-unsafe-webgpu', // required for WebGPU: Disabled -> Hardware accelerated
-    ...localeArgs(),
+    ...localeArgs(siteLocale('epic-games')),
   ],
   // The following makes the browser crash in docker with 'Chromium sandboxing failed!':
   // chromiumSandbox: true, // https://github.com/Kaliiiiiiiiii-Vinyzu/patchright/issues/52

--- a/fab.js
+++ b/fab.js
@@ -1,7 +1,7 @@
 import { chromium } from 'patchright';
 import { authenticator } from 'otplib';
 import { existsSync } from 'fs';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, closeContextSafely, log, cleanProfileLocks, localeArgs } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, closeContextSafely, log, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -21,7 +21,7 @@ import { siteVersion } from './src/sites.js';
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'fab', ...a);
 
 const URL_HOME = 'https://www.fab.com/';
-const URL_FREE = 'https://www.fab.com/limited-time-free';
+const URL_FREE = cfg.fab_page_url || 'https://www.fab.com/limited-time-free'; // FAB_PAGE_URL override
 const URL_ME = 'https://www.fab.com/i/users/me';
 
 log.section(`FAB (v${siteVersion('fab')})`);
@@ -34,7 +34,8 @@ cleanProfileLocks(cfg.dir.browser);
 const context = await chromium.launchPersistentContext(cfg.dir.browser, {
   headless: false, // don't use cfg.headless — like Epic, headless triggers captcha on the shared Epic login
   viewport: { width: cfg.width, height: cfg.height },
-  locale: 'en-US', // ignore OS locale so our English text locators match
+  locale: siteLocale('fab'), // see siteLocale() for the per-site locale policy
+  timezoneId: cfg.timezone_id,
   recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
   recordHar: cfg.record ? { path: `data/record/fab-${filenamify(datetime())}.har` } : undefined,
   handleSIGINT: false,
@@ -42,7 +43,7 @@ const context = await chromium.launchPersistentContext(cfg.dir.browser, {
     '--hide-crash-restore-bubble',
     '--ignore-gpu-blocklist',
     '--enable-unsafe-webgpu',
-    ...localeArgs(),
+    ...localeArgs(siteLocale('fab')),
   ],
 });
 

--- a/fanatical.js
+++ b/fanatical.js
@@ -1,6 +1,6 @@
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { chromium } from 'patchright';
-import { datetime, notify, log, dataDir, handleSIGINT, cleanProfileLocks, localeArgs } from './src/util.js';
+import { datetime, notify, log, dataDir, handleSIGINT, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -35,7 +35,7 @@ process.on('exit', code => {
   if (!code) log.summary(_summaryStats);
 });
 
-const URL_PAGE = 'https://www.fanatical.com/en/free-games-keys';
+const URL_PAGE = cfg.fanatical_page_url || 'https://www.fanatical.com/en/free-games-keys'; // FANATICAL_PAGE_URL override
 const STATE_FILE = dataDir('fanatical-watch.json');
 
 function loadState() {
@@ -70,9 +70,10 @@ try {
     // been captured.
     headless: false,
     viewport: { width: cfg.width, height: cfg.height },
-    locale: 'en-US',
+    locale: siteLocale('fanatical'), // see siteLocale() for the per-site locale policy
+    timezoneId: cfg.timezone_id,
     handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs()],
+    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('fanatical'))],
   });
   page = context.pages()[0] || await context.newPage();
   context.setDefaultTimeout(30000);

--- a/gog.js
+++ b/gog.js
@@ -1,7 +1,7 @@
 import { chromium } from 'patchright';
 import { existsSync, readFileSync, appendFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, log, normalizeTitle, awaitUserCaptchaSolve, cleanProfileLocks, matchKey, stripGpTail, getDiscoveryUserMarkedKeys, delay, localeArgs, dataDir } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, log, normalizeTitle, awaitUserCaptchaSolve, cleanProfileLocks, matchKey, stripGpTail, getDiscoveryUserMarkedKeys, delay, localeArgs, siteLocale, dataDir } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref } from './src/gamerpower.js';
@@ -41,7 +41,7 @@ function markOtpBackupCodeUsed(code) {
 
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'gog', ...a);
 
-const URL_CLAIM = 'https://www.gog.com/en';
+const URL_CLAIM = cfg.gog_page_url || 'https://www.gog.com/en'; // GOG_PAGE_URL override
 
 log.section(`GOG (v${siteVersion('gog')})`);
 
@@ -57,14 +57,15 @@ cleanProfileLocks(cfg.dir.browser);
 const context = await chromium.launchPersistentContext(cfg.dir.browser, {
   headless: cfg.headless,
   viewport: { width: cfg.width, height: cfg.height },
-  locale: 'en-US', // ignore OS locale to be sure to have english text for locators -> done via /en in URL
+  locale: siteLocale('gog'), // see siteLocale() for the per-site locale policy
+  timezoneId: cfg.timezone_id,
   recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated; without size, video would be scaled down to fit 800x800
   recordHar: cfg.record ? { path: `data/record/gog-${filenamify(datetime())}.har` } : undefined, // will record a HAR file with network requests and responses; can be imported in Chrome devtools
   handleSIGINT: false, // have to handle ourselves and call context.close(), otherwise recordings from above won't be saved
   // https://peter.sh/experiments/chromium-command-line-switches/
   args: [
     '--hide-crash-restore-bubble',
-    ...localeArgs(),
+    ...localeArgs(siteLocale('gog')),
   ],
 });
 

--- a/humble-bundle.js
+++ b/humble-bundle.js
@@ -1,6 +1,6 @@
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { chromium } from 'patchright';
-import { datetime, notify, log, dataDir, handleSIGINT, cleanProfileLocks, localeArgs } from './src/util.js';
+import { datetime, notify, log, dataDir, handleSIGINT, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -41,7 +41,7 @@ process.on('exit', code => {
 // search response. Iterating to a curated promo URL (e.g.
 // /store/promo/<slug>) once one is identified would make this
 // runner sharper.
-const URL_PAGE = 'https://www.humblebundle.com/store/search?sort=newest';
+const URL_PAGE = cfg.humble_page_url || 'https://www.humblebundle.com/store/search?sort=newest'; // HUMBLE_PAGE_URL override
 const STATE_FILE = dataDir('humble-bundle-watch.json');
 
 function loadState() {
@@ -66,9 +66,10 @@ try {
     // close the context once the API response has been captured.
     headless: false,
     viewport: { width: cfg.width, height: cfg.height },
-    locale: 'en-US',
+    locale: siteLocale('humble-bundle'), // see siteLocale() for the per-site locale policy
+    timezoneId: cfg.timezone_id,
     handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs()],
+    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('humble-bundle'))],
   });
   page = context.pages()[0] || await context.newPage();
   context.setDefaultTimeout(30000);

--- a/interactive-login.js
+++ b/interactive-login.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 const __panelDirname = path.dirname(fileURLToPath(import.meta.url));
 import { chromium } from 'patchright';
-import { datetime, notify, jsonDb, normalizeTitle, cleanProfileLocks, localeArgs, readDigestBuffer, markDigestFlushed } from './src/util.js';
+import { datetime, notify, jsonDb, normalizeTitle, cleanProfileLocks, localeArgs, siteLocale, readDigestBuffer, markDigestFlushed } from './src/util.js';
 import { cfg } from './src/config.js';
 import { describeConfig, patchConfig, describeEnv, getSchedulerConfig, CONFIG_FILE_PATH } from './src/app-config.js';
 import { SITES as SITE_REGISTRY, getLoginSitesById, getClaimScriptOrder, getLinkedActiveMap, getClaimDbFiles, getServiceRows } from './src/sites.js';
@@ -126,9 +126,10 @@ async function launchSite(siteId) {
   const context = await chromium.launchPersistentContext(site.browserDir, {
     headless: false,
     viewport: { width: cfg.width, height: cfg.height },
-    locale: 'en-US',
+    locale: siteLocale(siteId), // see siteLocale() for the per-site locale policy
+    timezoneId: cfg.timezone_id,
     handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs()],
+    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale(siteId))],
     ...(site.contextOptions || {}),
   });
 
@@ -211,9 +212,10 @@ async function checkSiteStatus(siteId) {
     context = await chromium.launchPersistentContext(site.browserDir, {
       headless: false,
       viewport: { width: cfg.width, height: cfg.height },
-      locale: 'en-US',
+      locale: siteLocale(siteId), // see siteLocale() for the per-site locale policy
+      timezoneId: cfg.timezone_id,
       handleSIGINT: false,
-      args: ['--hide-crash-restore-bubble', '--no-sandbox', '--disable-gpu', ...localeArgs()],
+      args: ['--hide-crash-restore-bubble', '--no-sandbox', '--disable-gpu', ...localeArgs(siteLocale(siteId))],
       ...(site.contextOptions || {}),
     });
 
@@ -320,9 +322,10 @@ async function importSiteCookies(siteId, rawCookies) {
     context = await chromium.launchPersistentContext(site.browserDir, {
       headless: false,
       viewport: { width: cfg.width, height: cfg.height },
-      locale: 'en-US',
+      locale: siteLocale(siteId), // see siteLocale() for the per-site locale policy
+      timezoneId: cfg.timezone_id,
       handleSIGINT: false,
-      args: ['--hide-crash-restore-bubble', ...localeArgs()],
+      args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale(siteId))],
       ...(site.contextOptions || {}),
     });
     await context.addCookies(normalized);
@@ -986,7 +989,8 @@ async function countPendingGogCodes() {
 }
 
 async function processOneRedeemCode(page, code) {
-  await page.goto(`https://www.gog.com/redeem/${encodeURIComponent(code)}`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  // /en keeps the success heading English regardless of context locale
+  await page.goto(`https://www.gog.com/en/redeem/${encodeURIComponent(code)}`, { waitUntil: 'domcontentloaded', timeout: 30000 });
   await page.waitForTimeout(2000);
   // URL-based pre-fill usually works; fall back to filling #codeInput explicitly.
   try { await page.fill('#codeInput', code); } catch {}
@@ -1152,9 +1156,10 @@ async function startBatchRedeem() {
   const context = await chromium.launchPersistentContext(cfg.dir.browser, {
     headless: false,
     viewport: { width: cfg.width, height: cfg.height },
-    locale: 'en-US',
+    locale: siteLocale('gog'), // see siteLocale() for the per-site locale policy
+    timezoneId: cfg.timezone_id,
     handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs()],
+    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('gog'))],
   });
   const page = context.pages()[0] || await context.newPage();
   try { await page.setViewportSize({ width: cfg.width, height: cfg.height }); } catch {}
@@ -1212,7 +1217,8 @@ function clearFinishedBatchRedeem() {
 // batch so we don't burn through more keys than necessary.
 let steamRedeem = null;
 
-const STEAM_REDEEM_URL = 'https://store.steampowered.com/account/registerkey';
+// ?l=english keeps the page English regardless of context locale (as steam.js does)
+const STEAM_REDEEM_URL = 'https://store.steampowered.com/account/registerkey?l=english';
 const STEAM_AJAX_URL = 'https://store.steampowered.com/account/ajaxregisterkey/';
 
 function collectPendingSteamCodes(dbs) {
@@ -1474,9 +1480,10 @@ async function startSteamRedeem() {
   const context = await chromium.launchPersistentContext(cfg.dir.browser, {
     headless: false,
     viewport: { width: cfg.width, height: cfg.height },
-    locale: 'en-US',
+    locale: siteLocale('steam'), // see siteLocale() for the per-site locale policy
+    timezoneId: cfg.timezone_id,
     handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs()],
+    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('steam'))],
   });
   const page = context.pages()[0] || await context.newPage();
   try { await page.setViewportSize({ width: cfg.width, height: cfg.height }); } catch {}

--- a/lenovo-gaming.js
+++ b/lenovo-gaming.js
@@ -25,7 +25,7 @@
 
 import { chromium } from 'patchright';
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { datetime, notify, log, dataDir, handleSIGINT, cleanProfileLocks, localeArgs } from './src/util.js';
+import { datetime, notify, log, dataDir, handleSIGINT, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -37,7 +37,7 @@ process.on('exit', code => {
   if (!code) log.summary(_summaryStats);
 });
 
-const URL_LISTING = 'https://gaming.lenovo.com/game-key-drops';
+const URL_LISTING = cfg.lenovo_page_url || 'https://gaming.lenovo.com/game-key-drops'; // LENOVO_PAGE_URL override
 const STATE_FILE = dataDir('lenovo-gaming-watch.json');
 
 function loadState() {
@@ -96,8 +96,9 @@ try {
   context = await chromium.launchPersistentContext(cfg.dir.browser + '-lenovo', {
     headless: false,
     viewport: { width: cfg.width, height: cfg.height },
-    locale: 'en-US',
-    args: ['--hide-crash-restore-bubble', '--no-sandbox', '--disable-gpu', ...localeArgs()],
+    locale: siteLocale('lenovo-gaming'), // see siteLocale() for the per-site locale policy
+    timezoneId: cfg.timezone_id,
+    args: ['--hide-crash-restore-bubble', '--no-sandbox', '--disable-gpu', ...localeArgs(siteLocale('lenovo-gaming'))],
   });
   page = context.pages()[0] || await context.newPage();
   context.setDefaultTimeout(cfg.debug ? 0 : cfg.timeout);

--- a/microsoft.js
+++ b/microsoft.js
@@ -1,7 +1,7 @@
 import { chromium, devices } from 'patchright';
 import { authenticator } from 'otplib';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { delay, datetime, prompt, notify, log, dataDir, jsonDb, cleanProfileLocks, localeArgs } from './src/util.js';
+import { delay, datetime, prompt, notify, log, dataDir, jsonDb, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
 import { cfg } from './src/config.js';
 import { describeConfig } from './src/app-config.js';
 import { siteVersion } from './src/sites.js';
@@ -294,7 +294,8 @@ async function createContext(isMobile) {
   const context = await chromium.launchPersistentContext(browserDir, {
     headless: false,
     viewport,
-    locale: 'en-US',
+    locale: siteLocale('microsoft'), // see siteLocale() for the per-site locale policy
+    timezoneId: cfg.timezone_id,
     handleSIGINT: false,
     args: [
       '--hide-crash-restore-bubble',
@@ -311,7 +312,7 @@ async function createContext(isMobile) {
       '--enable-webgl',
       '--ignore-gpu-blocklist',
       '--enable-unsafe-webgpu',
-      ...localeArgs(),
+      ...localeArgs(siteLocale('microsoft')),
     ],
     ...deviceSettings, // for mobile: overrides viewport, sets userAgent/isMobile/hasTouch
   });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^5.2.2",
+    "@types/node": "^26.1.1",
     "eslint": "^9.31.0"
   }
 }

--- a/prime-gaming.js
+++ b/prime-gaming.js
@@ -1,6 +1,6 @@
 import { chromium } from 'patchright';
 import { authenticator } from 'otplib';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, log, cleanProfileLocks, localeArgs } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, log, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -41,13 +41,14 @@ cleanProfileLocks(cfg.dir.browser);
 const context = await chromium.launchPersistentContext(cfg.dir.browser, {
   headless: cfg.headless,
   viewport: { width: cfg.width, height: cfg.height },
-  locale: 'en-US', // ignore OS locale to be sure to have english text for locators
+  locale: siteLocale('prime-gaming'), // see siteLocale() for the per-site locale policy
+  timezoneId: cfg.timezone_id,
   recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated; without size, video would be scaled down to fit 800x800
   recordHar: cfg.record ? { path: `data/record/pg-${filenamify(datetime())}.har` } : undefined, // will record a HAR file with network requests and responses; can be imported in Chrome devtools
   handleSIGINT: false, // have to handle ourselves and call context.close(), otherwise recordings from above won't be saved
   args: [
     '--hide-crash-restore-bubble',
-    ...localeArgs(),
+    ...localeArgs(siteLocale('prime-gaming')),
   ],
 });
 

--- a/src/config.js
+++ b/src/config.js
@@ -22,6 +22,14 @@ const ae    = svc['aliexpress']   || {};
 const ms    = svc['microsoft']    || {};
 const lenovo = svc['lenovo-gaming'] || {};
 
+// LANG is POSIX (e.g. de_DE.UTF-8); Playwright wants a BCP-47 tag (de-DE).
+// Strip the encoding, swap _ → -. C / POSIX / unparsable → '' (caller falls
+// back to en-US).
+const localeFromLang = lang => {
+  const tag = (lang || '').split('.')[0].split('@')[0].replace('_', '-').trim();
+  return /^[a-z]{2,3}(-[A-Za-z0-9]+)?$/i.test(tag) ? tag : '';
+};
+
 // Options - also see table in README.md
 export const cfg = {
   debug: process.env.DEBUG == '1' || process.env.PWDEBUG == '1', // runs non-headless and opens https://playwright.dev/docs/inspector
@@ -37,6 +45,22 @@ export const cfg = {
   },
   width: adv.width || 1920, // width of the opened browser
   height: adv.height || 1080, // height of the opened browser
+  // Fingerprint coherence so a non-US IP doesn't look like a US proxy: LANG
+  // sets the context locale (navigator.language / Accept-Language) and TZ its
+  // timezoneId. Unset = legacy en-US, no timezoneId. See siteLocale.
+  browser_locale: localeFromLang(process.env.LANG) || 'en-US',
+  timezone_id: process.env.TZ || undefined,
+  // Per-service base-URL overrides (<SVC>_PAGE_URL): escape hatch for
+  // locale/regional redirects. Unset = each service's built-in default.
+  eg_page_url: (process.env.EG_PAGE_URL || '').replace(/\/+$/, '') || undefined,
+  gog_page_url: (process.env.GOG_PAGE_URL || '').replace(/\/+$/, '') || undefined,
+  steam_page_url: (process.env.STEAM_PAGE_URL || '').replace(/\/+$/, '') || undefined,
+  fab_page_url: (process.env.FAB_PAGE_URL || '').replace(/\/+$/, '') || undefined,
+  humble_page_url: (process.env.HUMBLE_PAGE_URL || '').replace(/\/+$/, '') || undefined,
+  fanatical_page_url: (process.env.FANATICAL_PAGE_URL || '').replace(/\/+$/, '') || undefined,
+  lenovo_page_url: (process.env.LENOVO_PAGE_URL || '').replace(/\/+$/, '') || undefined,
+  ubisoft_page_url: (process.env.UBISOFT_PAGE_URL || '').replace(/\/+$/, '') || undefined,
+  ae_page_url: (process.env.AE_PAGE_URL || '').replace(/\/+$/, '') || undefined,
   run_history_max: adv.runHistoryMax || 200, // cap on data/runs.json entries (Logs tab Past-runs)
   timeout: (adv.timeoutSec || 60) * 1000, // default timeout for playwright is 30s
   login_timeout: (adv.loginTimeoutSec || 180) * 1000, // higher timeout for login, will wait twice: prompt + wait for manual login

--- a/src/util.js
+++ b/src/util.js
@@ -58,21 +58,31 @@ export const datetimeUTC = (d = new Date()) => d.toISOString().replace('T', ' ')
 export const datetime = (d = new Date()) => datetimeUTC(new Date(d.getTime() - d.getTimezoneOffset() * 60000));
 export const filenamify = s => s.replaceAll(':', '.').replace(/[^a-z0-9 _\-.]/gi, '_'); // alternative: https://www.npmjs.com/package/filenamify - On Unix-like systems, / is reserved. On Windows, <>:"/\|?* along with trailing periods are reserved.
 
-// Common Chromium launch flags every claim script should include. Force
-// English at the browser-process level (--lang + --accept-lang) and disable
-// Chrome's auto-translate so the DOM text our locators key off stays in
-// English regardless of the user's locale. Belt-and-suspenders with any
-// per-site URL-param locale forcing (e.g. Steam's ?l=english). Reported
-// originally as #68 (German Steam locale broke the "Add to Account"
-// locator) and #72 (Polish AliExpress broke the login-state detector) —
-// flag-level forcing fixes both in one place and covers every storefront
-// without per-site changes.
-export const localeArgs = () => [
-  '--lang=en-US',
-  '--accept-lang=en-US,en;q=0.9',
-  '--disable-translate',
-  '--disable-features=Translate,TranslateUI',
-];
+// Per-site context locale. Claim locators need English DOM text (#68 German
+// Steam, #72 Polish AliExpress), but a blanket en-US fingerprint on a non-US
+// IP is a proxy/bot signal. So: sites that force English via URL (Steam
+// ?l=english, GOG /en, Epic /en-US, Fanatical /en) or scrape locale-blind
+// (Humble/Lenovo) follow the LANG locale; the rest pin en-US to keep locators.
+const EN_PINNED_SITES = new Set(['prime-gaming', 'microsoft', 'microsoft-mobile', 'fab', 'aliexpress']);
+export const siteLocale = siteId => EN_PINNED_SITES.has(siteId) ? 'en-US' : cfg.browser_locale || 'en-US';
+
+// Chromium launch flags matching the context `locale` (pass siteLocale(id)):
+// set --lang/--accept-lang and disable auto-translate so DOM text stays in the
+// served language. The accept-lang chain keeps an English fallback (en;q=0.8).
+// Default en-US reproduces the exact legacy flags.
+export const localeArgs = (locale = cfg.browser_locale) => {
+  const loc = locale || 'en-US';
+  const base = loc.split('-')[0];
+  const accept = [loc];
+  if (base !== loc) accept.push(`${base};q=0.9`);
+  if (base !== 'en') accept.push('en;q=0.8');
+  return [
+    `--lang=${loc}`,
+    `--accept-lang=${accept.join(',')}`,
+    '--disable-translate',
+    '--disable-features=Translate,TranslateUI',
+  ];
+};
 
 // Load a previously-saved fingerprint from <profileDir>/.fgc-fingerprint.json
 // or call the supplied generator function once and persist its output.

--- a/steam.js
+++ b/steam.js
@@ -364,6 +364,13 @@ try {
       // nav items as button[type=submit] before the form, so a bare
       // button[type=submit].first() clicked those instead of signing in.
       await page.locator('button:has-text("Sign in")').first().click();
+      // Surface bad credentials instead of silently re-looping. Note Steam signs
+      // in with the account NAME, not the email — a common cause of this error.
+      page.getByText(/check your password and account name/i).first().waitFor({ timeout: cfg.login_timeout }).then(async () => {
+        log.error('Steam rejected the login — check STEAM_EMAIL (use your Steam account name, not your email address) and STEAM_PASSWORD');
+        await notify('steam: login failed — wrong account name or password.');
+        process.exit(1);
+      }).catch(() => {});
       page.waitForSelector('[class*="newlogindialog_AwaitingMobileConfLabel"], [class*="segmentedinputs"]').then(async () => {
         log.info('Steam Guard — enter the code from your authenticator app or email');
         const code = await prompt({ type: 'text', message: 'Enter Steam Guard code', validate: n => n.toString().length == 5 || 'The code must be 5 characters!' });

--- a/steam.js
+++ b/steam.js
@@ -356,11 +356,14 @@ try {
       // matched it first when the React class selectors were stale, so the email
       // was typed into store search and the login looped without ever signing in.
       await page.waitForSelector('input[type="password"]', { timeout: cfg.login_timeout });
-      const usernameInput = page.locator('input[type="text"]._2GBWeup5cttgbTw8FM3tfx, input[type="text"][class*="newlogindialog"], input[type="text"]:not(#store_nav_search_term)').first();
+      const usernameInput = page.locator('input[type="text"]._2GBWeup5cttgbTw8FM3tfx, form:has(input[type="password"]) input[type="text"]:not([name="term"])').first();
       const passwordInput = page.locator('input[type="password"]').first();
       await usernameInput.fill(email);
       await passwordInput.fill(password);
-      await page.locator('button[type="submit"], button:has-text("Sign in")').first().click();
+      // Match the login form's "Sign in" by text — the store header renders its
+      // nav items as button[type=submit] before the form, so a bare
+      // button[type=submit].first() clicked those instead of signing in.
+      await page.locator('button:has-text("Sign in")').first().click();
       page.waitForSelector('[class*="newlogindialog_AwaitingMobileConfLabel"], [class*="segmentedinputs"]').then(async () => {
         log.info('Steam Guard — enter the code from your authenticator app or email');
         const code = await prompt({ type: 'text', message: 'Enter Steam Guard code', validate: n => n.toString().length == 5 || 'The code must be 5 characters!' });
@@ -371,8 +374,8 @@ try {
               await inputs[i].fill(code[i]);
             }
           } else {
-            await page.locator('input[type="text"]').first().fill(code);
-            await page.locator('button[type="submit"], button:has-text("Submit")').first().click();
+            await page.locator('#twofactorcode_entry, input[type="text"]:not([name="term"])').first().fill(code);
+            await page.locator('button:has-text("Submit"), #login_twofactorauth_buttonset_entercode button').first().click();
           }
         }
       }).catch(_ => {});

--- a/steam.js
+++ b/steam.js
@@ -349,8 +349,14 @@ try {
     const email = cfg.steam_email || await prompt({ message: 'Enter Steam email/username' });
     const password = email && (cfg.steam_password || await prompt({ type: 'password', message: 'Enter Steam password' }));
     if (email && password) {
-      await page.waitForTimeout(2000);
-      const usernameInput = page.locator('input[type="text"]._2GBWeup5cttgbTw8FM3tfx, input[type="text"][class*="newlogindialog"], input[type="text"]').first();
+      // Wait for the real login form to render — its password field is unique to
+      // the login dialog, whereas the store header only carries the search box.
+      // Then target the username input excluding that search box
+      // (#store_nav_search_term): the old bare `input[type="text"]` fallback
+      // matched it first when the React class selectors were stale, so the email
+      // was typed into store search and the login looped without ever signing in.
+      await page.waitForSelector('input[type="password"]', { timeout: cfg.login_timeout });
+      const usernameInput = page.locator('input[type="text"]._2GBWeup5cttgbTw8FM3tfx, input[type="text"][class*="newlogindialog"], input[type="text"]:not(#store_nav_search_term)').first();
       const passwordInput = page.locator('input[type="password"]').first();
       await usernameInput.fill(email);
       await passwordInput.fill(password);

--- a/steam.js
+++ b/steam.js
@@ -1,6 +1,6 @@
 import { chromium } from 'patchright';
 import { writeFileSync } from 'node:fs';
-import { resolve, jsonDb, datetime, filenamify, prompt, notify, html_game_list, handleSIGINT, log, dataDir, cleanProfileLocks, matchKey, stripGpTail, getDiscoveryUserMarkedKeys, localeArgs } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, notify, html_game_list, handleSIGINT, log, dataDir, cleanProfileLocks, matchKey, stripGpTail, getDiscoveryUserMarkedKeys, localeArgs, siteLocale } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref } from './src/gamerpower.js';
@@ -8,7 +8,7 @@ import { fetchFGFPosts, filterFor as filterFgfFor, cleanTitle as fgfClean } from
 
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'steam', ...a);
 
-const URL_STORE = 'https://store.steampowered.com';
+const URL_STORE = cfg.steam_page_url || 'https://store.steampowered.com'; // STEAM_PAGE_URL override
 const URL_LOGIN = `${URL_STORE}/login/`;
 
 // All our store-page selectors and success indicators key off English text
@@ -76,13 +76,14 @@ cleanProfileLocks(cfg.dir.browser);
 const context = await chromium.launchPersistentContext(cfg.dir.browser, {
   headless: cfg.headless,
   viewport: { width: cfg.width, height: cfg.height },
-  locale: 'en-US',
+  locale: siteLocale('steam'), // see siteLocale() for the per-site locale policy
+  timezoneId: cfg.timezone_id,
   recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
   recordHar: cfg.record ? { path: `data/record/steam-${filenamify(datetime())}.har` } : undefined,
   handleSIGINT: false,
   args: [
     '--hide-crash-restore-bubble',
-    ...localeArgs(),
+    ...localeArgs(siteLocale('steam')),
   ],
 });
 
@@ -329,7 +330,7 @@ try {
     { name: 'Steam_Language', value: 'english', domain: 'store.steampowered.com', path: '/' },
   ]);
 
-  await page.goto(URL_STORE, { waitUntil: 'domcontentloaded' });
+  await page.goto(withEnglish(URL_STORE), { waitUntil: 'domcontentloaded' });
   await page.waitForTimeout(3000);
 
   const isLoggedIn = async () => {
@@ -340,7 +341,7 @@ try {
   while (!await isLoggedIn()) {
     log.warn('Not signed in to Steam');
     if (cfg.nowait) process.exit(1);
-    await page.goto(URL_LOGIN, { waitUntil: 'domcontentloaded' });
+    await page.goto(withEnglish(URL_LOGIN), { waitUntil: 'domcontentloaded' });
     if (!cfg.debug) context.setDefaultTimeout(cfg.login_timeout);
     log.status('Login timeout', `${cfg.login_timeout / 1000}s`);
     if (cfg.steam_email && cfg.steam_password) log.info('Using credentials from environment');
@@ -372,7 +373,7 @@ try {
       try {
         await page.waitForURL('https://store.steampowered.com/', { timeout: cfg.login_timeout });
       } catch {
-        await page.goto(URL_STORE, { waitUntil: 'domcontentloaded' });
+        await page.goto(withEnglish(URL_STORE), { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(3000);
       }
     } else {
@@ -386,7 +387,7 @@ try {
       await page.waitForSelector('#account_pulldown', { timeout: cfg.login_timeout });
     }
     if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
-    await page.goto(URL_STORE, { waitUntil: 'domcontentloaded' });
+    await page.goto(withEnglish(URL_STORE), { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(2000);
   }
 

--- a/ubisoft.js
+++ b/ubisoft.js
@@ -1,5 +1,6 @@
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { datetime, notify, log, dataDir, handleSIGINT } from './src/util.js';
+import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
 // Watch-only Ubisoft Connect free-games tracker. No login, no claim — just
@@ -21,7 +22,7 @@ process.on('exit', code => {
   if (!code) log.summary(_summaryStats);
 });
 
-const URL_FREE = 'https://store.ubisoft.com/us/free-games';
+const URL_FREE = cfg.ubisoft_page_url || 'https://store.ubisoft.com/us/free-games'; // UBISOFT_PAGE_URL override
 const STATE_FILE = dataDir('ubisoft-watch.json');
 
 function loadState() {


### PR DESCRIPTION
## Summary

General improvements to locale / timezone / fingerprint handling. Previously
every browser context launched with a hardcoded `en-US` locale and no timezone.
On a non-US IP that mismatch reads as a proxy/bot — my Steam sessions were being
flagged as a bot. Aligning the context locale and timezone with the environment
fixed the detection.

## Changes

- **config**: derive `browser_locale` from POSIX `LANG` (`de_DE.UTF-8` → `de-DE`,
  fallback `en-US`); add `timezone_id` from `TZ`; add per-service
  `<SVC>_PAGE_URL` base-URL overrides.
- **util**: add `siteLocale()` — sites that force English via URL (Steam, GOG,
  Epic, Fanatical) or scrape locale-blind (Humble, Lenovo) follow `LANG`; the
  rest (Prime, Microsoft, Fab, AliExpress) stay pinned to `en-US` to keep their
  locators matching. `localeArgs(locale)` now builds matching `--lang` /
  `--accept-lang`.
- **claim scripts + panel**: every `launchPersistentContext` now uses
  `siteLocale(id)` + context `timezoneId`; GOG (`/en`) and Steam (`?l=english`)
  redeem URLs pinned so success headings stay English regardless of locale.
- **deps / docs**: add `@types/node` (editor types); document `LANG`, `TZ`,
  `<SVC>_PAGE_URL`.
  
 ## Note

I'm already running this code myself and it's been working well. Still, no rush
to merge — if you'd prefer, feel free to spin this off into a testing branch
first so users can try it out before it lands on `main`. Whatever makes you most
comfortable works for me.