### PR TITLE
refactor(browser): extract launchContext factory

### DIFF
--- a/aliexpress.js
+++ b/aliexpress.js
@@ -2,8 +2,8 @@
 // services.aliexpress.active === true (Settings → Per-service → AliExpress).
 // If you run it standalone on the CLI, it always executes; the activation
 // gate lives in interactive-login.js.
-import { chromium } from 'patchright';
-import { datetime, filenamify, prompt, handleSIGINT, jsonDb, awaitUserCaptchaSolve, getOrCreateFingerprint, log, notify, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
+import { datetime, prompt, jsonDb, awaitUserCaptchaSolve, getOrCreateFingerprint, log, notify } from './src/util.js';
+import { launchContext } from './src/browser.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 import { FingerprintInjector } from 'fingerprint-injector';
@@ -33,31 +33,23 @@ const { fingerprint, headers, _persisted } = getOrCreateFingerprint(profileDir, 
 );
 log.status('Fingerprint', _persisted ? 'loaded from cache' : 'fresh (saved for next run)');
 
-cleanProfileLocks(profileDir);
-const context = await chromium.launchPersistentContext(profileDir, {
-  headless: cfg.headless,
-  locale: siteLocale('aliexpress'), // see siteLocale() for the per-site locale policy
-  timezoneId: cfg.timezone_id,
-  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
-  recordHar: cfg.record ? { path: `data/record/aliexpress-${filenamify(datetime())}.har` } : undefined,
-  handleSIGINT: false,
-  // mobile view is required — desktop URLs just show "install the app"
-  userAgent: fingerprint.navigator.userAgent,
-  viewport: {
-    width: fingerprint.screen.width,
-    height: fingerprint.screen.height,
+const { context, page } = await launchContext('aliexpress', {
+  profileDir,
+  contextOptions: {
+    // mobile view is required — desktop URLs just show "install the app"
+    userAgent: fingerprint.navigator.userAgent,
+    viewport: {
+      width: fingerprint.screen.width,
+      height: fingerprint.screen.height,
+    },
+    extraHTTPHeaders: {
+      'accept-language': headers['accept-language'],
+    },
   },
-  extraHTTPHeaders: {
-    'accept-language': headers['accept-language'],
-  },
-  args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('aliexpress'))],
 });
-handleSIGINT(context);
 await new FingerprintInjector().attachFingerprintToPlaywright(context, { fingerprint, headers });
 
 context.setDefaultTimeout(cfg.debug ? 0 : cfg.timeout);
-
-const page = context.pages().length ? context.pages()[0] : await context.newPage();
 
 const auth = async url => {
   console.log('auth', url);

--- a/epic-games.js
+++ b/epic-games.js
@@ -2,7 +2,8 @@ import { chromium } from 'patchright';
 import { authenticator } from 'otplib';
 import path from 'path';
 import { existsSync, writeFileSync } from 'fs';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, closeContextSafely, log, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, closeContextSafely, log } from './src/util.js';
+import { launchContext } from './src/browser.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 import { getMobileGames } from './src/epic-games-mobile.js';
@@ -41,35 +42,19 @@ const db = await jsonDb('epic-games.json', {});
 if (cfg.time) console.time('startup');
 
 // https://playwright.dev/docs/auth#multi-factor-authentication
-cleanProfileLocks(cfg.dir.browser);
-const context = await chromium.launchPersistentContext(cfg.dir.browser, {
-  // channel: 'chrome', // recommended, but `npx patchright install chrome` clashes with system Chrome - https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-nodejs#best-practice----use-chrome-without-fingerprint-injection
-  headless: false, // don't use cfg.headless headless here since SHOW=0 will lead to captcha
-  viewport: { width: cfg.width, height: cfg.height },
-  locale: siteLocale('epic-games'), // see siteLocale() for the per-site locale policy
-  timezoneId: cfg.timezone_id,
-  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated; without size, video would be scaled down to fit 800x800
-  recordHar: cfg.record ? { path: `data/record/eg-${filenamify(datetime())}.har` } : undefined, // will record a HAR file with network requests and responses; can be imported in Chrome devtools
-  handleSIGINT: false, // have to handle ourselves and call context.close(), otherwise recordings from above won't be saved
-  // https://peter.sh/experiments/chromium-command-line-switches/
-  args: [
-    '--hide-crash-restore-bubble',
-    '--ignore-gpu-blocklist', // required for OpenGL: Disabled -> Enabled & WebGL: Software only -> Hardware accelerated
-    '--enable-unsafe-webgpu', // required for WebGPU: Disabled -> Hardware accelerated
-    ...localeArgs(siteLocale('epic-games')),
-  ],
-  // The following makes the browser crash in docker with 'Chromium sandboxing failed!':
-  // chromiumSandbox: true, // https://github.com/Kaliiiiiiiiii-Vinyzu/patchright/issues/52
+const { context, page } = await launchContext('epic-games', {
+  recordPrefix: 'eg',
+  // headless:false — SHOW=0 (headless) leads to captcha on the Epic login.
+  contextOptions: { headless: false },
+  // --ignore-gpu-blocklist: OpenGL/WebGL software-only -> hardware accelerated.
+  // --enable-unsafe-webgpu: WebGPU disabled -> hardware accelerated.
+  extraArgs: ['--ignore-gpu-blocklist', '--enable-unsafe-webgpu'],
 });
 
 // console.log(context.browser().browserType()); // browser is null...
 if (cfg.debug) console.log(chromium.executablePath());
 
-handleSIGINT(context);
-
 if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
-
-const page = context.pages().length ? context.pages()[0] : await context.newPage(); // should always exist
 // await page.setViewportSize({ width: cfg.width, height: cfg.height }); // TODO workaround for https://github.com/vogler/free-games-claimer/issues/277 until Playwright fixes it
 
 // some debug info about the page (screen dimensions, user agent, platform)

--- a/fab.js
+++ b/fab.js
@@ -1,7 +1,8 @@
 import { chromium } from 'patchright';
 import { authenticator } from 'otplib';
 import { existsSync } from 'fs';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, closeContextSafely, log, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, closeContextSafely, log } from './src/util.js';
+import { launchContext } from './src/browser.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -30,30 +31,15 @@ const db = await jsonDb('fab.json', {});
 
 if (cfg.time) console.time('startup');
 
-cleanProfileLocks(cfg.dir.browser);
-const context = await chromium.launchPersistentContext(cfg.dir.browser, {
-  headless: false, // don't use cfg.headless — like Epic, headless triggers captcha on the shared Epic login
-  viewport: { width: cfg.width, height: cfg.height },
-  locale: siteLocale('fab'), // see siteLocale() for the per-site locale policy
-  timezoneId: cfg.timezone_id,
-  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
-  recordHar: cfg.record ? { path: `data/record/fab-${filenamify(datetime())}.har` } : undefined,
-  handleSIGINT: false,
-  args: [
-    '--hide-crash-restore-bubble',
-    '--ignore-gpu-blocklist',
-    '--enable-unsafe-webgpu',
-    ...localeArgs(siteLocale('fab')),
-  ],
+const { context, page } = await launchContext('fab', {
+  // headless:false — like Epic, headless triggers captcha on the shared Epic login
+  contextOptions: { headless: false },
+  extraArgs: ['--ignore-gpu-blocklist', '--enable-unsafe-webgpu'],
 });
 
 if (cfg.debug) console.log(chromium.executablePath());
 
-handleSIGINT(context);
-
 if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
-
-const page = context.pages().length ? context.pages()[0] : await context.newPage();
 
 const notify_assets = [];
 let user;

--- a/fanatical.js
+++ b/fanatical.js
@@ -1,6 +1,6 @@
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { chromium } from 'patchright';
-import { datetime, notify, log, dataDir, handleSIGINT, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
+import { datetime, notify, log, dataDir, handleSIGINT } from './src/util.js';
+import { launchContext } from './src/browser.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -62,20 +62,14 @@ let apiResponses = 0;        // /api/all-promotions/* responses seen
 let freeProductsSeen = 0;    // total entries in freeProducts arrays
 let noSpendPromos = 0;       // entries with min_spend.USD == 0
 try {
-  cleanProfileLocks(cfg.dir.browser);
-  context = await chromium.launchPersistentContext(cfg.dir.browser, {
-    // Headed chromium — the container only ships full chrome, not the
-    // separate chrome-headless-shell. Page renders into the unused VNC
-    // surface; we close the context as soon as the API response has
-    // been captured.
-    headless: false,
-    viewport: { width: cfg.width, height: cfg.height },
-    locale: siteLocale('fanatical'), // see siteLocale() for the per-site locale policy
-    timezoneId: cfg.timezone_id,
-    handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('fanatical'))],
-  });
-  page = context.pages()[0] || await context.newPage();
+  // headless:false — the container only ships full chrome, not the separate
+  // chrome-headless-shell. Page renders into the unused VNC surface; we close
+  // the context as soon as the API response has been captured.
+  ({ context, page } = await launchContext('fanatical', {
+    record: false,
+    sigint: false, // handleSIGINT() already registered above
+    contextOptions: { headless: false },
+  }));
   context.setDefaultTimeout(30000);
 
   // Intercept any /api/ JSON response. Fanatical's exact freebie

--- a/gog.js
+++ b/gog.js
@@ -1,7 +1,7 @@
-import { chromium } from 'patchright';
+import { launchContext } from './src/browser.js';
 import { existsSync, readFileSync, appendFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, log, normalizeTitle, awaitUserCaptchaSolve, cleanProfileLocks, matchKey, stripGpTail, getDiscoveryUserMarkedKeys, delay, localeArgs, siteLocale, dataDir } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, log, normalizeTitle, awaitUserCaptchaSolve, matchKey, stripGpTail, getDiscoveryUserMarkedKeys, delay, dataDir } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref } from './src/gamerpower.js';
@@ -53,27 +53,10 @@ if (cfg.width < 1280) { // otherwise 'Sign in' and #menuUsername are hidden (but
 }
 
 // https://playwright.dev/docs/auth#multi-factor-authentication
-cleanProfileLocks(cfg.dir.browser);
-const context = await chromium.launchPersistentContext(cfg.dir.browser, {
-  headless: cfg.headless,
-  viewport: { width: cfg.width, height: cfg.height },
-  locale: siteLocale('gog'), // see siteLocale() for the per-site locale policy
-  timezoneId: cfg.timezone_id,
-  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated; without size, video would be scaled down to fit 800x800
-  recordHar: cfg.record ? { path: `data/record/gog-${filenamify(datetime())}.har` } : undefined, // will record a HAR file with network requests and responses; can be imported in Chrome devtools
-  handleSIGINT: false, // have to handle ourselves and call context.close(), otherwise recordings from above won't be saved
-  // https://peter.sh/experiments/chromium-command-line-switches/
-  args: [
-    '--hide-crash-restore-bubble',
-    ...localeArgs(siteLocale('gog')),
-  ],
-});
-
-handleSIGINT(context);
+const { context, page } = await launchContext('gog');
 
 if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
 
-const page = context.pages().length ? context.pages()[0] : await context.newPage(); // should always exist
 await page.setViewportSize({ width: cfg.width, height: cfg.height }); // TODO workaround for https://github.com/vogler/free-games-claimer/issues/277 until Playwright fixes it
 // console.debug('userAgent:', await page.evaluate(() => navigator.userAgent));
 

--- a/humble-bundle.js
+++ b/humble-bundle.js
@@ -1,6 +1,6 @@
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { chromium } from 'patchright';
-import { datetime, notify, log, dataDir, handleSIGINT, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
+import { datetime, notify, log, dataDir, handleSIGINT } from './src/util.js';
+import { launchContext } from './src/browser.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -58,20 +58,14 @@ function saveState(state) {
 let context, page;
 let captured = []; // accumulates products from any matching API responses
 try {
-  cleanProfileLocks(cfg.dir.browser);
-  context = await chromium.launchPersistentContext(cfg.dir.browser, {
-    // Match the project pattern (other site scripts use headed chromium
-    // because the container only ships the full chrome binary, not the
-    // separate chrome-headless-shell). The page renders into VNC; we
-    // close the context once the API response has been captured.
-    headless: false,
-    viewport: { width: cfg.width, height: cfg.height },
-    locale: siteLocale('humble-bundle'), // see siteLocale() for the per-site locale policy
-    timezoneId: cfg.timezone_id,
-    handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('humble-bundle'))],
-  });
-  page = context.pages()[0] || await context.newPage();
+  // headless:false — the container only ships the full chrome binary, not
+  // the separate chrome-headless-shell. The page renders into VNC; we close
+  // the context once the API response has been captured.
+  ({ context, page } = await launchContext('humble-bundle', {
+    record: false,
+    sigint: false, // handleSIGINT() already registered above
+    contextOptions: { headless: false },
+  }));
   context.setDefaultTimeout(30000);
 
   // Listen for the JSON the page itself fetches to populate the grid.

--- a/interactive-login.js
+++ b/interactive-login.js
@@ -4,8 +4,8 @@ import { watch, readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 const __panelDirname = path.dirname(fileURLToPath(import.meta.url));
-import { chromium } from 'patchright';
-import { datetime, notify, jsonDb, normalizeTitle, cleanProfileLocks, localeArgs, siteLocale, readDigestBuffer, markDigestFlushed } from './src/util.js';
+import { datetime, notify, jsonDb, normalizeTitle, cleanProfileLocks, readDigestBuffer, markDigestFlushed } from './src/util.js';
+import { launchContext } from './src/browser.js';
 import { cfg } from './src/config.js';
 import { describeConfig, patchConfig, describeEnv, getSchedulerConfig, CONFIG_FILE_PATH } from './src/app-config.js';
 import { SITES as SITE_REGISTRY, getLoginSitesById, getClaimScriptOrder, getLinkedActiveMap, getClaimDbFiles, getServiceRows } from './src/sites.js';
@@ -122,20 +122,15 @@ async function launchSite(siteId) {
 
   console.log(`[${datetime()}] Launching browser for ${site.name}...`);
 
-  cleanProfileLocks(site.browserDir);
-  const context = await chromium.launchPersistentContext(site.browserDir, {
-    headless: false,
-    viewport: { width: cfg.width, height: cfg.height },
-    locale: siteLocale(siteId), // see siteLocale() for the per-site locale policy
-    timezoneId: cfg.timezone_id,
-    handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale(siteId))],
-    ...(site.contextOptions || {}),
+  const { context, page } = await launchContext(siteId, {
+    profileDir: site.browserDir,
+    record: false,
+    sigint: false, // panel owns the browser lifecycle (activeBrowser / closeBrowser)
+    contextOptions: { headless: false, ...(site.contextOptions || {}) },
   });
 
   context.setDefaultTimeout(0);
 
-  const page = context.pages().length ? context.pages()[0] : await context.newPage();
   if (!site.contextOptions?.viewport) await page.setViewportSize({ width: cfg.width, height: cfg.height });
   await page.goto(site.loginUrl, { waitUntil: 'domcontentloaded' });
 
@@ -208,18 +203,14 @@ async function checkSiteStatus(siteId) {
 
   let context;
   try {
-    cleanProfileLocks(site.browserDir);
-    context = await chromium.launchPersistentContext(site.browserDir, {
-      headless: false,
-      viewport: { width: cfg.width, height: cfg.height },
-      locale: siteLocale(siteId), // see siteLocale() for the per-site locale policy
-      timezoneId: cfg.timezone_id,
-      handleSIGINT: false,
-      args: ['--hide-crash-restore-bubble', '--no-sandbox', '--disable-gpu', ...localeArgs(siteLocale(siteId))],
-      ...(site.contextOptions || {}),
-    });
-
-    const page = context.pages()[0] || await context.newPage();
+    let page;
+    ({ context, page } = await launchContext(siteId, {
+      profileDir: site.browserDir,
+      record: false,
+      sigint: false,
+      contextOptions: { headless: false, ...(site.contextOptions || {}) },
+      extraArgs: ['--no-sandbox', '--disable-gpu'],
+    }));
     const result = await site.checkLogin(page);
     siteStatus[siteId] = {
       status: result.loggedIn ? 'logged_in' : 'not_logged_in',
@@ -318,16 +309,12 @@ async function importSiteCookies(siteId, rawCookies) {
   console.log(`[${datetime()}] Importing ${normalized.length} cookie(s) into ${site.name} profile (${matches.length} match host ${targetHost})`);
   let context;
   try {
-    cleanProfileLocks(site.browserDir);
-    context = await chromium.launchPersistentContext(site.browserDir, {
-      headless: false,
-      viewport: { width: cfg.width, height: cfg.height },
-      locale: siteLocale(siteId), // see siteLocale() for the per-site locale policy
-      timezoneId: cfg.timezone_id,
-      handleSIGINT: false,
-      args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale(siteId))],
-      ...(site.contextOptions || {}),
-    });
+    ({ context } = await launchContext(siteId, {
+      profileDir: site.browserDir,
+      record: false,
+      sigint: false,
+      contextOptions: { headless: false, ...(site.contextOptions || {}) },
+    }));
     await context.addCookies(normalized);
   } finally {
     if (context) { try { await context.close(); } catch {} }
@@ -1152,16 +1139,11 @@ async function startBatchRedeem() {
   if (!pending.length) throw new Error('No pending GOG codes to redeem.');
 
   console.log(`[${datetime()}] Starting batch redeem for ${pending.length} GOG code(s)...`);
-  cleanProfileLocks(cfg.dir.browser);
-  const context = await chromium.launchPersistentContext(cfg.dir.browser, {
-    headless: false,
-    viewport: { width: cfg.width, height: cfg.height },
-    locale: siteLocale('gog'), // see siteLocale() for the per-site locale policy
-    timezoneId: cfg.timezone_id,
-    handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('gog'))],
+  const { context, page } = await launchContext('gog', {
+    record: false,
+    sigint: false,
+    contextOptions: { headless: false },
   });
-  const page = context.pages()[0] || await context.newPage();
   try { await page.setViewportSize({ width: cfg.width, height: cfg.height }); } catch {}
   context.setDefaultTimeout(0); // batch-redeem drives its own timeouts
 
@@ -1476,16 +1458,11 @@ async function startSteamRedeem() {
   if (!pending.length) throw new Error('No pending Steam keys to redeem.');
 
   console.log(`[${datetime()}] Starting Steam batch redeem for ${pending.length} key(s)...`);
-  cleanProfileLocks(cfg.dir.browser);
-  const context = await chromium.launchPersistentContext(cfg.dir.browser, {
-    headless: false,
-    viewport: { width: cfg.width, height: cfg.height },
-    locale: siteLocale('steam'), // see siteLocale() for the per-site locale policy
-    timezoneId: cfg.timezone_id,
-    handleSIGINT: false,
-    args: ['--hide-crash-restore-bubble', ...localeArgs(siteLocale('steam'))],
+  const { context, page } = await launchContext('steam', {
+    record: false,
+    sigint: false,
+    contextOptions: { headless: false },
   });
-  const page = context.pages()[0] || await context.newPage();
   try { await page.setViewportSize({ width: cfg.width, height: cfg.height }); } catch {}
   context.setDefaultTimeout(0);
 

--- a/lenovo-gaming.js
+++ b/lenovo-gaming.js
@@ -23,9 +23,9 @@
 // canonically. Listing-fetch is one HTTP round trip; detail fetches only
 // run for drops that are new or whose schedule we don't have cached.
 
-import { chromium } from 'patchright';
+import { launchContext } from './src/browser.js';
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { datetime, notify, log, dataDir, handleSIGINT, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
+import { datetime, notify, log, dataDir, handleSIGINT } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -92,15 +92,13 @@ function statusFromTitle(title) {
 
 let context, page;
 try {
-  cleanProfileLocks(cfg.dir.browser + '-lenovo');
-  context = await chromium.launchPersistentContext(cfg.dir.browser + '-lenovo', {
-    headless: false,
-    viewport: { width: cfg.width, height: cfg.height },
-    locale: siteLocale('lenovo-gaming'), // see siteLocale() for the per-site locale policy
-    timezoneId: cfg.timezone_id,
-    args: ['--hide-crash-restore-bubble', '--no-sandbox', '--disable-gpu', ...localeArgs(siteLocale('lenovo-gaming'))],
-  });
-  page = context.pages()[0] || await context.newPage();
+  ({ context, page } = await launchContext('lenovo-gaming', {
+    profileDir: cfg.dir.browser + '-lenovo',
+    record: false,
+    sigint: false, // handleSIGINT() already registered above
+    contextOptions: { headless: false },
+    extraArgs: ['--no-sandbox', '--disable-gpu'],
+  }));
   context.setDefaultTimeout(cfg.debug ? 0 : cfg.timeout);
 
   log.status('Fetching', URL_LISTING);

--- a/microsoft.js
+++ b/microsoft.js
@@ -1,7 +1,8 @@
-import { chromium, devices } from 'patchright';
+import { devices } from 'patchright';
+import { launchContext } from './src/browser.js';
 import { authenticator } from 'otplib';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { delay, datetime, prompt, notify, log, dataDir, jsonDb, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
+import { delay, datetime, prompt, notify, log, dataDir, jsonDb } from './src/util.js';
 import { cfg } from './src/config.js';
 import { describeConfig } from './src/app-config.js';
 import { siteVersion } from './src/sites.js';
@@ -290,31 +291,25 @@ async function createContext(isMobile) {
     height: cfg.height + Math.floor(Math.random() * 41) - 20, // ±20px
   };
 
-  cleanProfileLocks(browserDir);
-  const context = await chromium.launchPersistentContext(browserDir, {
-    headless: false,
-    viewport,
-    locale: siteLocale('microsoft'), // see siteLocale() for the per-site locale policy
-    timezoneId: cfg.timezone_id,
-    handleSIGINT: false,
-    args: [
-      '--hide-crash-restore-bubble',
-      // GPU / WebGL fingerprint hardening. In a container without GPU
-      // passthrough, Chromium without these flags can end up with WebGL
-      // either disabled or in a weird "broken-WebGL" state — both are
-      // stronger bot tells than the consistent "software-rendered WebGL"
-      // fingerprint you get with SwiftShader (vendor "Google Inc.",
-      // renderer "Google SwiftShader"). Suggested by @mzernetsch on #56
-      // as part of the set of changes that historically cleared MS's
-      // "Unusual search activity" banner. --enable-webgl is default-on
-      // in modern Chromium but kept explicit so the intent is readable.
-      '--use-gl=swiftshader',
-      '--enable-webgl',
-      '--ignore-gpu-blocklist',
-      '--enable-unsafe-webgpu',
-      ...localeArgs(siteLocale('microsoft')),
-    ],
-    ...deviceSettings, // for mobile: overrides viewport, sets userAgent/isMobile/hasTouch
+  const { context } = await launchContext('microsoft', {
+    profileDir: browserDir,
+    record: false,
+    sigint: false, // MS Rewards manages its own lifecycle; no SIGINT handler here
+    contextOptions: {
+      headless: false,
+      viewport,
+      ...deviceSettings, // for mobile: overrides viewport, sets userAgent/isMobile/hasTouch
+    },
+    // GPU / WebGL fingerprint hardening. In a container without GPU
+    // passthrough, Chromium without these flags can end up with WebGL
+    // either disabled or in a weird "broken-WebGL" state — both are
+    // stronger bot tells than the consistent "software-rendered WebGL"
+    // fingerprint you get with SwiftShader (vendor "Google Inc.",
+    // renderer "Google SwiftShader"). Suggested by @mzernetsch on #56
+    // as part of the set of changes that historically cleared MS's
+    // "Unusual search activity" banner. --enable-webgl is default-on
+    // in modern Chromium but kept explicit so the intent is readable.
+    extraArgs: ['--use-gl=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist', '--enable-unsafe-webgpu'],
   });
 
   if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);

--- a/prime-gaming.js
+++ b/prime-gaming.js
@@ -1,6 +1,6 @@
-import { chromium } from 'patchright';
+import { launchContext } from './src/browser.js';
 import { authenticator } from 'otplib';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, log, cleanProfileLocks, localeArgs, siteLocale } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, log } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 
@@ -37,26 +37,10 @@ for (const userRecords of Object.values(db.data || {})) {
 }
 
 // https://playwright.dev/docs/auth#multi-factor-authentication
-cleanProfileLocks(cfg.dir.browser);
-const context = await chromium.launchPersistentContext(cfg.dir.browser, {
-  headless: cfg.headless,
-  viewport: { width: cfg.width, height: cfg.height },
-  locale: siteLocale('prime-gaming'), // see siteLocale() for the per-site locale policy
-  timezoneId: cfg.timezone_id,
-  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated; without size, video would be scaled down to fit 800x800
-  recordHar: cfg.record ? { path: `data/record/pg-${filenamify(datetime())}.har` } : undefined, // will record a HAR file with network requests and responses; can be imported in Chrome devtools
-  handleSIGINT: false, // have to handle ourselves and call context.close(), otherwise recordings from above won't be saved
-  args: [
-    '--hide-crash-restore-bubble',
-    ...localeArgs(siteLocale('prime-gaming')),
-  ],
-});
-
-handleSIGINT(context);
+const { context, page } = await launchContext('prime-gaming', { recordPrefix: 'pg' });
 
 if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
 
-const page = context.pages().length ? context.pages()[0] : await context.newPage(); // should always exist
 await page.setViewportSize({ width: cfg.width, height: cfg.height }); // TODO workaround for https://github.com/vogler/free-games-claimer/issues/277 until Playwright fixes it
 // console.debug('userAgent:', await page.evaluate(() => navigator.userAgent));
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,56 @@
+import { chromium } from 'patchright';
+// Import util.js before config.js: the two form a cycle (config.js needs
+// dataDir from util.js; util.js reads cfg from config.js at module top-level).
+// Since claim scripts now import this module first, util-first is the order
+// that lets cfg finish initializing before util's top-level code runs it.
+import { cleanProfileLocks, localeArgs, siteLocale, handleSIGINT, datetime, filenamify } from './util.js';
+import { cfg } from './config.js';
+
+// Shared browser-context factory. Every claim script used to repeat the same
+// preamble verbatim — cleanProfileLocks + launchPersistentContext with the same
+// headless/viewport/locale/timezone/SIGINT wiring and the same base Chromium
+// args. That copy-paste is extracted here so the defaults live in one place.
+//
+// Behaviour-preserving by design: per-site differences (extra GPU args, custom
+// profile dir, fingerprint/device overrides, recording) are passed in via
+// options rather than baked in, so migrating a script does not change what it
+// launches.
+
+/**
+ * Launch a persistent Chromium context with the shared scraper defaults.
+ *
+ * @param {string} siteId  site id — drives the per-site locale policy (siteLocale) and the default HAR filename.
+ * @param {object} [opts]
+ * @param {string} [opts.profileDir]  persistent profile directory (default: cfg.dir.browser).
+ * @param {string} [opts.recordPrefix]  HAR filename prefix under data/record/ (default: siteId).
+ * @param {boolean} [opts.record]  force recording on/off (default: cfg.record).
+ * @param {string[]} [opts.extraArgs]  extra Chromium args appended after the base set.
+ * @param {object} [opts.contextOptions]  extra launchPersistentContext options, merged last (e.g. userAgent, extraHTTPHeaders, device settings). Do not pass `args` here — use extraArgs.
+ * @param {boolean} [opts.sigint]  register handleSIGINT(context) so Ctrl-C closes cleanly (default: true).
+ * @returns {Promise<{ context: import('patchright').BrowserContext, page: import('patchright').Page }>}
+ */
+export async function launchContext(siteId, {
+  profileDir = cfg.dir.browser,
+  recordPrefix = siteId,
+  record = cfg.record,
+  extraArgs = [],
+  contextOptions = {},
+  sigint = true,
+} = {}) {
+  cleanProfileLocks(profileDir);
+  const locale = siteLocale(siteId);
+  const context = await chromium.launchPersistentContext(profileDir, {
+    headless: cfg.headless,
+    viewport: { width: cfg.width, height: cfg.height },
+    locale, // see siteLocale() for the per-site locale policy
+    timezoneId: cfg.timezone_id,
+    recordVideo: record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated
+    recordHar: record ? { path: `data/record/${recordPrefix}-${filenamify(datetime())}.har` } : undefined, // network requests/responses, importable in Chrome devtools
+    handleSIGINT: false, // handled ourselves via handleSIGINT(context) so recordings flush on Ctrl-C
+    args: ['--hide-crash-restore-bubble', ...localeArgs(locale), ...extraArgs],
+    ...contextOptions,
+  });
+  if (sigint) handleSIGINT(context);
+  const page = context.pages().length ? context.pages()[0] : await context.newPage(); // should always exist
+  return { context, page };
+}

--- a/steam.js
+++ b/steam.js
@@ -1,6 +1,6 @@
-import { chromium } from 'patchright';
+import { launchContext } from './src/browser.js';
 import { writeFileSync } from 'node:fs';
-import { resolve, jsonDb, datetime, filenamify, prompt, notify, html_game_list, handleSIGINT, log, dataDir, cleanProfileLocks, matchKey, stripGpTail, getDiscoveryUserMarkedKeys, localeArgs, siteLocale } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, notify, html_game_list, log, dataDir, matchKey, stripGpTail, getDiscoveryUserMarkedKeys } from './src/util.js';
 import { cfg } from './src/config.js';
 import { siteVersion } from './src/sites.js';
 import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref } from './src/gamerpower.js';
@@ -72,26 +72,10 @@ for (const userRecords of Object.values(db.data || {})) {
   }
 }
 
-cleanProfileLocks(cfg.dir.browser);
-const context = await chromium.launchPersistentContext(cfg.dir.browser, {
-  headless: cfg.headless,
-  viewport: { width: cfg.width, height: cfg.height },
-  locale: siteLocale('steam'), // see siteLocale() for the per-site locale policy
-  timezoneId: cfg.timezone_id,
-  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
-  recordHar: cfg.record ? { path: `data/record/steam-${filenamify(datetime())}.har` } : undefined,
-  handleSIGINT: false,
-  args: [
-    '--hide-crash-restore-bubble',
-    ...localeArgs(siteLocale('steam')),
-  ],
-});
-
-handleSIGINT(context);
+const { context, page } = await launchContext('steam');
 
 if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
 
-const page = context.pages().length ? context.pages()[0] : await context.newPage();
 await page.setViewportSize({ width: cfg.width, height: cfg.height });
 
 const notify_games = [];


### PR DESCRIPTION
Centralize the launchPersistentContext preamble (cleanProfileLocks + locale/timezone/args/SIGINT + page) into a src/browser.js factory. The 10 scrapers that open a context and the 5 panel launches now call it; per-site differences (record, GPU extraArgs, profileDir, fingerprint/device) go through options. Net -128 lines.

The factory imports util.js before config.js because of the config<->util cycle — otherwise scripts crash with 'Cannot access cfg before initialization' since they import browser.js first.