### PR TITLE
refactor: move claim scrapers and the panel into src/, add subpath import aliases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,27 @@ The DB is a `{ user: { gameId: entry } }` map. The redeemers scan every claim DB
 If you find yourself needing engine changes to make your script work — a new `scheduleKind`, a new `coerce` kind, a new `feature` flag consumer — open an issue describing the gap rather than working around it locally. The whole point of the registry is that *normal* collectors don't need engine touches.
 
 
+## Import paths
+
+`package.json` declares two subpath aliases, so an import never counts `../`
+levels and moving a file leaves its imports untouched:
+
+| Alias | Resolves to | Use for |
+|---|---|---|
+| `#src/*` | `./src/*` | shared modules — `#src/util.js`, `#src/config.js`, `#src/sites.js` |
+| `#platforms/*` | `./src/platforms/*` | the per-store runner scripts |
+
+```js
+import { cfg } from '#src/config.js';   // same line from any depth
+```
+
+New and moved files should use the aliases. Files that predate them still use
+relative paths and are migrated as they are touched, so both styles appear in
+the tree.
+
+These are an *import* mechanism only: `#platforms/gog.js` is not a valid
+argument to `node`, so anything that shells out to a runner needs a real path.
+
 ## Building and publishing docker images
 
 Setup the secrets for DOCKERHUB_USERNAME and [DOCKERHUB_TOKEN](https://hub.docker.com/settings/security) in `https://github.com/YOUR_USERNAME/free-games-claimer/settings/secrets/actions` to be able to run the docker.yml workflows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 
 ## Adding a new collector
 
-The engine routes everything through `src/sites.js` (the registry) plus a per-site runner script. To add a new claim/watch site, two files change: a registry entry and a `<id>.js` runner.
+The engine routes everything through `src/sites.js` (the registry) plus a per-site runner script. To add a new claim/watch site, two files change: a registry entry and a `src/platforms/<id>.js` runner.
 
 ### 1. Register it in `src/sites.js`
 
@@ -22,7 +22,7 @@ Append an entry to the `SITES` array. Required fields:
 |---|---|
 | `id` | stable identifier (lowercase, hyphenated) — used in config keys, deep links, claim DB filename |
 | `name` | human-readable label shown in cards and notifications |
-| `script` | runner filename at repo root (`'foo.js'`); `null` for sub-services that share a parent's script |
+| `script` | `platformScript('foo')` — resolves through the `#platforms/*` alias and returns a repo-root-relative path. The extension is optional: `'foo'`, `'foo.js'` and `'foo.js.js'` all yield `src/platforms/foo.js`. `null` for sub-services that share a parent's script |
 | `loginUrl` | page to navigate to for interactive login; `null` for no-login services (watchers) |
 | `browserDir` | getter (`get browserDir() { return cfg.dir.browser; }`) — most services share the profile; suffix it (`+ '-foo'`) for an isolated profile |
 | `defaultActive` | `true` for default-on, `false` for opt-in |
@@ -65,19 +65,19 @@ Coerce descriptors recognized by `src/app-config.js`:
 
 A new kind needs a case added to `coerceFromDescriptor` in `src/app-config.js`.
 
-### 3. Write the runner script (`<id>.js` at repo root)
+### 3. Write the runner script (`src/platforms/<id>.js`)
 
-Spawned as a standalone Node process by the panel. Use `epic-games.js` or `gog.js` as a starting template. Contract:
+Spawned as a standalone Node process by the panel. Use `src/platforms/epic-games.js` or `src/platforms/gog.js` as a starting template. Contract:
 
 - Read settings from `cfg.<field>` (loader flattens registry settings into `cfg` — see `src/config.js`).
 - Read credentials directly from `process.env.<NAME>` (credentials stay env-only by design — never put them in the registry).
 - Launch the browser via `chromium.launchPersistentContext(cfg.dir.browser, …)` (or your isolated profile if `browserDir` differs).
 - Per game/event, write an entry to the claim DB via `jsonDb('<id>.json', {})` from `src/util.js`.
 - For human-solvable captchas, wrap the wait in `awaitUserCaptchaSolve(page, { service, captchaCheck, … })` from `src/util.js` — emits the `[CAPTCHA-START]` / `[CAPTCHA-END]` markers the panel watches for, and the user solves via the embedded VNC.
-- Stamp the script's run-log header with the registry-defined version. Import `siteVersion` from `./src/sites.js` and use it as the first log line, matching the project convention:
+- Stamp the script's run-log header with the registry-defined version. Import `siteVersion` via the `#src/*` alias (see *Import paths*) and use it as the first log line, matching the project convention:
 
   ```js
-  import { siteVersion } from './src/sites.js';
+  import { siteVersion } from '#src/sites.js';
   log.section(`Your Site Name (v${siteVersion('your-site-id')})`);
   log.status('Time', datetime());
   ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,5 +163,6 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=15s CMD curl --fail http:
 
 # Script to setup display server & VNC is always executed.
 ENTRYPOINT ["docker-entrypoint.sh"]
-# Default command to run. This is replaced by appending own command, e.g. `docker run ... node prime-gaming` to only run this script.
-CMD node prime-gaming; node epic-games; node gog; node steam; node microsoft
+# Default command to run. This is replaced by appending own command, e.g. `docker run ... node src/platforms/prime-gaming` to only run this script.
+# TODO: hold the runner dir in an ENV so entries stay bare names.
+CMD node src/platforms/prime-gaming; node src/platforms/epic-games; node src/platforms/gog; node src/platforms/steam; node src/platforms/microsoft

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
       # - LOOP=28800 # scheduler interval in seconds (e.g., 28800 = 8 hours); omit to disable scheduler
       # - BASE_PATH=/free-games # URL prefix if the panel is proxied under a subfolder
       # - PUBLIC_URL=https://example.com/free-games # full external URL used in notifications
-      # - CLAIM_CMD='node src/platforms/gog.js; node src/platforms/prime-gaming.js; node src/platforms/epic-games.js; node src/platforms/steam.js; node src/platforms/microsoft.js' # full scheduled claim command (default includes all)
-      # - CLAIM_CMD_MANUAL='node src/platforms/gog.js; node src/platforms/prime-gaming.js; node src/platforms/epic-games.js; node src/platforms/steam.js' # "Run Now" button command (default skips microsoft.js since it sleeps internally until MS_SCHEDULE_START)
+      # - CLAIM_CMD='gog.js; prime-gaming.js; epic-games.js; steam.js; microsoft.js' # full scheduled claim command (default includes all); bare script names resolve to their current location
+      # - CLAIM_CMD_MANUAL='gog.js; prime-gaming.js; epic-games.js; steam.js' # "Run Now" button command (default skips microsoft.js since it sleeps internally until MS_SCHEDULE_START)
       # - STEAM_MIN_RATING=6 # minimum review rating 1-9 (6 = Mostly Positive)
       # - STEAM_MIN_PRICE=10 # minimum original price in USD
       # - MS_EMAIL=your@email.com # Microsoft account for Bing Rewards (defaults to EMAIL)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "7080:7080" # control panel (always running)
     volumes:
       - fgc:/fgc/data
-    # command: bash -c "node epic-games; node gog; node steam"  # override CLAIM_CMD below instead
+    # command: bash -c "node src/platforms/epic-games; node src/platforms/gog; node src/platforms/steam"  # override CLAIM_CMD below instead
     # To set env vars, uncomment `environment:` below AND at least one entry
     # (an `environment:` key with only comments under it is null, which newer
     # Docker Compose rejects with "environment must be a mapping").
@@ -25,8 +25,8 @@ services:
       # - LOOP=28800 # scheduler interval in seconds (e.g., 28800 = 8 hours); omit to disable scheduler
       # - BASE_PATH=/free-games # URL prefix if the panel is proxied under a subfolder
       # - PUBLIC_URL=https://example.com/free-games # full external URL used in notifications
-      # - CLAIM_CMD='node gog.js; node prime-gaming.js; node epic-games.js; node steam.js; node microsoft.js' # full scheduled claim command (default includes all)
-      # - CLAIM_CMD_MANUAL='node gog.js; node prime-gaming.js; node epic-games.js; node steam.js' # "Run Now" button command (default skips microsoft.js since it sleeps internally until MS_SCHEDULE_START)
+      # - CLAIM_CMD='node src/platforms/gog.js; node src/platforms/prime-gaming.js; node src/platforms/epic-games.js; node src/platforms/steam.js; node src/platforms/microsoft.js' # full scheduled claim command (default includes all)
+      # - CLAIM_CMD_MANUAL='node src/platforms/gog.js; node src/platforms/prime-gaming.js; node src/platforms/epic-games.js; node src/platforms/steam.js' # "Run Now" button command (default skips microsoft.js since it sleeps internally until MS_SCHEDULE_START)
       # - STEAM_MIN_RATING=6 # minimum review rating 1-9 (6 = Mostly Positive)
       # - STEAM_MIN_PRICE=10 # minimum original price in USD
       # - MS_EMAIL=your@email.com # Microsoft account for Bing Rewards (defaults to EMAIL)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -155,4 +155,4 @@ fi
 if [ "$LOGIN_MODE" = "1" ]; then
   echo "  (LOGIN_MODE=1 is deprecated — panel is always running; you can remove this env var)"
 fi
-exec tini -s -g -- node interactive-login.js
+exec tini -s -g -- node src/panel/panel.js

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -49,7 +49,7 @@ for `BASE_PATH`, `PUBLIC_URL`, and `NOVNC_URL`.
 |--------|---------|-------------|
 | `NOTIFY_TITLE` | | Optional title for notifications |
 | `NOTIFY_ATTACH_SCREENSHOTS` | `1` | Attach the most recent screenshot to failure notifications. Set to `0` to keep notifications text-only (privacy / bandwidth). Also editable in **Settings → Notifications**. |
-| `CLAIM_CMD` | (active services in claim order) | Shell command the scheduler runs at its anchored wake. Built dynamically from the active services in the registry's claim order; set this to override with a fixed pipeline. |
+| `CLAIM_CMD` | (active services in claim order) | Shell command the scheduler runs at its anchored wake. Built dynamically from the active services in the registry's claim order; set this to override with a fixed pipeline. Name the scripts however you like — `gog.js`, `gog`, `node gog.js` and a full path all resolve to the current location of the runner, so an override written for an older layout keeps working. Steps that aren't recognized scripts (a custom pre/post command, anything with its own directory) run exactly as written. |
 | `CLAIM_CMD_MANUAL` | (active services minus microsoft) | Shell command for a manual chain run *with no sites picker* (e.g. driven from an external invocation). Since 2.5.3 the panel's **Run Now** button opens a per-run picker modal where the user checks specific services for that run; the picker defaults match this exclusion (everything except microsoft.js, since a paced MS run adds ~30-45 min). Override this env only if you have a CLI / cron caller that needs a fixed pipeline. |
 | `SHOW` | `1` (Docker) | Show browser GUI. Default is headless outside Docker. |
 | `WIDTH` | `1920` | Browser/screen width |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -65,7 +65,7 @@ volumes:
   fgc:
 ```
 
-> **Important:** Don't override `command:` or `entrypoint:`. The image's entrypoint launches the control panel, and the panel owns scheduling, the Run-Now button, and the per-service active toggles. Replacing it with a hand-rolled `node prime-gaming; node epic-games; …` pipeline disables all of that.
+> **Important:** Don't override `command:` or `entrypoint:`. The image's entrypoint launches the control panel, and the panel owns scheduling, the Run-Now button, and the per-service active toggles. Replacing it with a hand-rolled `node src/platforms/prime-gaming; node src/platforms/epic-games; …` pipeline disables all of that.
 
 ---
 
@@ -105,10 +105,10 @@ The panel's update pill works fine alongside any of these — it just stops appe
    ```
 4. Run individual claimers:
    ```sh
-   node prime-gaming
-   node epic-games
-   node gog
-   node steam
+   node src/platforms/prime-gaming
+   node src/platforms/epic-games
+   node src/platforms/gog
+   node src/platforms/steam
    ```
 5. Optional: install [apprise](https://github.com/caronc/apprise) for notifications (`pipx install apprise`)
 6. To update: `git pull && npm install`

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -8,7 +8,7 @@ Reverse-proxy configurations for serving the panel and noVNC behind your own dom
 
 ## Reverse-Proxy Setup
 
-The interactive-login panel can be served behind a reverse proxy. There are three
+The control panel can be served behind a reverse proxy. There are three
 common deployment shapes, each with its own env vars. Pick the one that matches
 how your proxy routes traffic — the others stay unset.
 

--- a/interactive-login.js
+++ b/interactive-login.js
@@ -1765,7 +1765,8 @@ function runAllScripts({ source = 'panel', sites = null, extraEnv = null } = {})
       // per-card test), mark today's MS schedule fired so the decoupled MS
       // loop won't re-fire later the same day. Without this, a manual
       // 09:00 click + scheduled 10:48 fire would double-run MS.
-      if (code === 0 && /\bnode microsoft\.js\b/.test(cmd)) {
+      // Basename, not `node <path>`: the registry owns the path, and it moves.
+      if (code === 0 && /\bmicrosoft\.js\b/.test(cmd)) {
         try { markMsRunFiredToday(); } catch {}
       }
       // Persist the scheduler-main completion timestamp so a panel

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "#rootDir": "./"
   },
   "engines": {
-    "node": ">=17"
+    "node": ">=20.6.0"
   },
   "dependencies": {
     "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "#src/*": "./src/*",
     "#platforms/*": "./src/platforms/*",
     "#dataDir": "./data",
-    "#rootDir": "./"
+    "#rootDir": "./package.json"
   },
   "engines": {
     "node": ">=20.6.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
     "deps:update": "npx taze major -w && npm i"
   },
   "type": "module",
+  "imports": {
+    "#src/*": "./src/*",
+    "#platforms/*": "./src/platforms/*",
+    "#dataDir": "./data",
+    "#rootDir": "./"
+  },
   "engines": {
     "node": ">=17"
   },

--- a/src/app-config.js
+++ b/src/app-config.js
@@ -430,7 +430,7 @@ function maskLast4(s) {
 }
 
 // Live scheduler config read — bypasses the module-level cfg so the scheduler
-// loop (which lives in interactive-login.js) can re-read after a config save
+// loop (which lives in src/panel/panel.js) can re-read after a config save
 // and reschedule without a panel restart.
 export function getSchedulerConfig() {
   const s = describeConfig().effective.scheduler || {};

--- a/src/app-config.js
+++ b/src/app-config.js
@@ -18,10 +18,11 @@ import { SITES } from './sites.js';
 
 // Compute the data-dir path directly instead of importing dataDir from util.js.
 // util.js itself imports cfg from config.js (for top-level enquirer setup),
-// and config.js is now our caller — importing from util.js here recreates the
-// cycle and dataDir ends up in TDZ when we need it.
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const CONFIG_FILE = path.resolve(__dirname, '..', 'data', 'config.json');
+// and config.js is now our caller — importing dataDir from util.js here
+// recreates the cycle and it lands in TDZ when we need it. Resolving the alias
+// directly gives the same anchor with no import, and without depending on how
+// deep this file sits.
+const CONFIG_FILE = path.resolve(fileURLToPath(import.meta.resolve('#dataDir')), 'config.json');
 
 const toBool = v => v === '1' || v === 'true' || v === true;
 // EG_MOBILE is inverted in the original: absent or truthy → true, only '0'/'false' → false.

--- a/src/config.js
+++ b/src/config.js
@@ -87,7 +87,7 @@ export const cfg = {
   // Priority for time-sensitive captcha notifications. Default high so it
   // breaks through DnD; user can dial down via Settings → Notifications.
   captcha_notify_priority: notif.captchaPriority || 'high',
-  // scheduler (moved out of interactive-login.js so Settings can override)
+  // scheduler (moved out of src/panel/panel.js so Settings can override)
   loop: sched.loopSeconds ?? 0,
   daily_start_time: sched.dailyStartTime ?? '',
   ms_schedule_hours: sched.msScheduleHours ?? 0,

--- a/src/github-watch.js
+++ b/src/github-watch.js
@@ -14,7 +14,7 @@
 //     only — GitHub's not involved in the read-tracking.
 //
 // This module is CommonJS-style ESM: only exports the top-level poll +
-// state accessors. The Alerts-tab wiring lives in interactive-login.js.
+// state accessors. The Alerts-tab wiring lives in src/panel/panel.js.
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { dataDir } from './util.js';

--- a/src/panel/panel.js
+++ b/src/panel/panel.js
@@ -1,17 +1,15 @@
 import http from 'node:http';
 import { spawn, execFile } from 'node:child_process';
 import { watch, readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-const __panelDirname = path.dirname(fileURLToPath(import.meta.url));
-import { datetime, notify, jsonDb, normalizeTitle, cleanProfileLocks, readDigestBuffer, markDigestFlushed, stripGpTail } from './src/util.js';
-import { launchContext } from './src/browser.js';
-import { cfg } from './src/config.js';
-import { describeConfig, patchConfig, describeEnv, getSchedulerConfig, CONFIG_FILE_PATH } from './src/app-config.js';
-import { SITES as SITE_REGISTRY, getLoginSitesById, getClaimScriptOrder, getLinkedActiveMap, getClaimDbFiles, getServiceRows } from './src/sites.js';
-import { fetchGamerPowerGiveaways, filterFor as filterGpFor, COLLECTOR_PATTERNS as GP_COLLECTOR_PATTERNS, GP_TITLE_HINTS } from './src/gamerpower.js';
-import { fetchFGFPosts, filterFor as filterFgfFor, cleanTitle as fgfCleanTitle, COLLECTOR_TITLE_PATTERNS as FGF_COLLECTOR_PATTERNS } from './src/freegamefindings.js';
-import { pollGithubReplies, getWatchState as getGithubWatchState, markIssueRead as markGithubIssueRead } from './src/github-watch.js';
+import { datetime, notify, jsonDb, normalizeTitle, cleanProfileLocks, readDigestBuffer, markDigestFlushed, stripGpTail, dataDir, rootDir } from '#src/util.js';
+import { launchContext } from '#src/browser.js';
+import { cfg } from '#src/config.js';
+import { describeConfig, patchConfig, describeEnv, getSchedulerConfig, CONFIG_FILE_PATH } from '#src/app-config.js';
+import { SITES as SITE_REGISTRY, getLoginSitesById, getClaimScriptOrder, getLinkedActiveMap, getClaimDbFiles, getServiceRows } from '#src/sites.js';
+import { fetchGamerPowerGiveaways, filterFor as filterGpFor, COLLECTOR_PATTERNS as GP_COLLECTOR_PATTERNS, GP_TITLE_HINTS } from '#src/gamerpower.js';
+import { fetchFGFPosts, filterFor as filterFgfFor, cleanTitle as fgfCleanTitle, COLLECTOR_TITLE_PATTERNS as FGF_COLLECTOR_PATTERNS } from '#src/freegamefindings.js';
+import { pollGithubReplies, getWatchState as getGithubWatchState, markIssueRead as markGithubIssueRead } from '#src/github-watch.js';
 
 const PANEL_PORT = Number(process.env.PANEL_PORT) || 7080;
 const NOVNC_PORT = process.env.NOVNC_PORT || 6080;
@@ -26,7 +24,7 @@ const PANEL_PASSWORD = process.env.PANEL_PASSWORD || process.env.VNC_PASSWORD ||
 const BASE_PATH = cfg.base_path; // e.g. "/free-games" when behind a subfolder proxy, or ""
 const PUBLIC_URL = cfg.public_url || `http://localhost:${PANEL_PORT}${BASE_PATH}`;
 const APP_VERSION = (() => {
-  try { return JSON.parse(readFileSync(path.join(__panelDirname, 'package.json'), 'utf8')).version || ''; }
+  try { return JSON.parse(readFileSync(rootDir('package.json'), 'utf8')).version || ''; }
   catch { return ''; }
 })();
 
@@ -1834,7 +1832,7 @@ let nextMainRun = null;       // Date | null — main chain wake
 let nextMsRun = null;         // Date | null — MS-only wake (decoupled mode)
 let msTodayState = null;      // last-read MS schedule state, for getState()
 
-const MS_SCHEDULE_FILE = path.resolve(__panelDirname, 'data', 'ms-schedule-today.json');
+const MS_SCHEDULE_FILE = dataDir('ms-schedule-today.json');
 
 function todayKey(d = new Date()) {
   return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
@@ -1896,7 +1894,7 @@ function pickMsTargetFor(dateKey, c) {
 // emit their `[RUN-SUCCESS] service=<id>` marker (parsed in the stdout
 // handler), persisted to data/last-runs.json so the Sessions tab can show
 // "Last Successful Run …" on each card across panel restarts.
-const LAST_RUNS_FILE = path.resolve(__panelDirname, 'data', 'last-runs.json');
+const LAST_RUNS_FILE = dataDir('last-runs.json');
 let lastRunSuccess = {};
 function loadLastRuns() {
   try {
@@ -2413,7 +2411,7 @@ async function msSchedulerLoop() {
 // notification and stamps the per-drop notifications.* field so the same wake
 // doesn't re-fire on next loop iteration.
 
-const LENOVO_STATE_FILE = path.resolve(__panelDirname, 'data', 'lenovo-gaming-watch.json');
+const LENOVO_STATE_FILE = dataDir('lenovo-gaming-watch.json');
 let nextLenovoWake = null; // { dropId, kind, target } | null
 
 function readLenovoState() {
@@ -9590,7 +9588,7 @@ const server = http.createServer(async (req, res) => {
         if (rel && !rel.includes('..') && !rel.includes('/')) assetPath = rel;
       }
       if (assetPath) {
-        const full = path.join(__panelDirname, 'assets', assetPath);
+        const full = path.join(rootDir('assets'), assetPath);
         if (existsSync(full)) {
           const ext = path.extname(assetPath).toLowerCase();
           const ct = { '.png': 'image/png', '.ico': 'image/x-icon', '.svg': 'image/svg+xml', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg' }[ext] || 'application/octet-stream';

--- a/src/panel/panel.js
+++ b/src/panel/panel.js
@@ -6,7 +6,7 @@ import { datetime, notify, jsonDb, normalizeTitle, cleanProfileLocks, readDigest
 import { launchContext } from '#src/browser.js';
 import { cfg } from '#src/config.js';
 import { describeConfig, patchConfig, describeEnv, getSchedulerConfig, CONFIG_FILE_PATH } from '#src/app-config.js';
-import { SITES as SITE_REGISTRY, getLoginSitesById, getClaimScriptOrder, getLinkedActiveMap, getClaimDbFiles, getServiceRows } from '#src/sites.js';
+import { SITES as SITE_REGISTRY, getLoginSitesById, getClaimScriptOrder, getLinkedActiveMap, getClaimDbFiles, getServiceRows, normalizeClaimCommand } from '#src/sites.js';
 import { fetchGamerPowerGiveaways, filterFor as filterGpFor, COLLECTOR_PATTERNS as GP_COLLECTOR_PATTERNS, GP_TITLE_HINTS } from '#src/gamerpower.js';
 import { fetchFGFPosts, filterFor as filterFgfFor, cleanTitle as fgfCleanTitle, COLLECTOR_TITLE_PATTERNS as FGF_COLLECTOR_PATTERNS } from '#src/freegamefindings.js';
 import { pollGithubReplies, getWatchState as getGithubWatchState, markIssueRead as markGithubIssueRead } from '#src/github-watch.js';
@@ -886,7 +886,13 @@ function buildClaimCommand({ manual = false, sites = null } = {}) {
 function resolveClaimCommand({ manual, sites = null }) {
   if (!sites) {
     const envKey = manual ? 'CLAIM_CMD_MANUAL' : 'CLAIM_CMD';
-    if (process.env[envKey]) return process.env[envKey];
+    const raw = process.env[envKey];
+    if (raw) {
+      const cmd = normalizeClaimCommand(raw);
+      // Running something other than what the user wrote should be visible.
+      if (cmd !== raw) console.log(`[${datetime()}] ${envKey}: resolved runner paths — running \`${cmd}\``);
+      return cmd;
+    }
   }
   return buildClaimCommand({ manual, sites });
 }

--- a/src/platforms/aliexpress.js
+++ b/src/platforms/aliexpress.js
@@ -2,10 +2,10 @@
 // services.aliexpress.active === true (Settings → Per-service → AliExpress).
 // If you run it standalone on the CLI, it always executes; the activation
 // gate lives in interactive-login.js.
-import { datetime, prompt, jsonDb, awaitUserCaptchaSolve, getOrCreateFingerprint, log, notify } from './src/util.js';
-import { launchContext } from './src/browser.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
+import { datetime, prompt, jsonDb, awaitUserCaptchaSolve, getOrCreateFingerprint, log, notify } from '#src/util.js';
+import { launchContext } from '#src/browser.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
 import { FingerprintInjector } from 'fingerprint-injector';
 import { FingerprintGenerator } from 'fingerprint-generator';
 

--- a/src/platforms/aliexpress.js
+++ b/src/platforms/aliexpress.js
@@ -1,7 +1,7 @@
 // Opt-in service — the panel's runner only invokes this script when
 // services.aliexpress.active === true (Settings → Per-service → AliExpress).
 // If you run it standalone on the CLI, it always executes; the activation
-// gate lives in interactive-login.js.
+// gate lives in src/panel/panel.js.
 import { datetime, prompt, jsonDb, awaitUserCaptchaSolve, getOrCreateFingerprint, log, notify } from '#src/util.js';
 import { launchContext } from '#src/browser.js';
 import { cfg } from '#src/config.js';

--- a/src/platforms/epic-games.js
+++ b/src/platforms/epic-games.js
@@ -2,13 +2,13 @@ import { chromium } from 'patchright';
 import { authenticator } from 'otplib';
 import path from 'path';
 import { existsSync, writeFileSync } from 'fs';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, closeContextSafely, log } from './src/util.js';
-import { launchContext, gotoWithRetry } from './src/browser.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
-import { getMobileGames } from './src/epic-games-mobile.js';
-import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref, unhandledPlatforms as gpUnhandled } from './src/gamerpower.js';
-import { fetchFGFPosts, filterFor as filterFgfFor, unhandledPlatforms as fgfUnhandled, cleanTitle as fgfClean } from './src/freegamefindings.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, closeContextSafely, log } from '#src/util.js';
+import { launchContext, gotoWithRetry } from '#src/browser.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
+import { getMobileGames } from '#src/epic-games-mobile.js';
+import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref, unhandledPlatforms as gpUnhandled } from '#src/gamerpower.js';
+import { fetchFGFPosts, filterFor as filterFgfFor, unhandledPlatforms as fgfUnhandled, cleanTitle as fgfClean } from '#src/freegamefindings.js';
 
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'epic-games', ...a);
 

--- a/src/platforms/fab.js
+++ b/src/platforms/fab.js
@@ -1,10 +1,10 @@
 import { chromium } from 'patchright';
 import { authenticator } from 'otplib';
 import { existsSync } from 'fs';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, closeContextSafely, log } from './src/util.js';
-import { launchContext, gotoWithRetry } from './src/browser.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, closeContextSafely, log } from '#src/util.js';
+import { launchContext, gotoWithRetry } from '#src/browser.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
 
 // FAB (fab.com) is Epic's unified 3D-content marketplace. Each month it
 // gives away a set of "Limited-Time Free" assets that can be permanently

--- a/src/platforms/fanatical.js
+++ b/src/platforms/fanatical.js
@@ -1,8 +1,8 @@
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { datetime, notify, log, dataDir, handleSIGINT } from './src/util.js';
-import { launchContext, gotoWithRetry } from './src/browser.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
+import { datetime, notify, log, dataDir, handleSIGINT } from '#src/util.js';
+import { launchContext, gotoWithRetry } from '#src/browser.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
 
 // Watch-only Fanatical free-Steam-keys tracker. No login, no auto-claim
 // — loads fanatical.com/en/free-games-keys in a real browser (their

--- a/src/platforms/gog.js
+++ b/src/platforms/gog.js
@@ -1,11 +1,11 @@
-import { launchContext, gotoWithRetry } from './src/browser.js';
+import { launchContext, gotoWithRetry } from '#src/browser.js';
 import { existsSync, readFileSync, appendFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, log, normalizeTitle, awaitUserCaptchaSolve, matchKey, stripGpTail, getDiscoveryUserMarkedKeys, delay, dataDir } from './src/util.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
-import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref } from './src/gamerpower.js';
-import { fetchFGFPosts, filterFor as filterFgfFor, cleanTitle as fgfClean } from './src/freegamefindings.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, log, normalizeTitle, awaitUserCaptchaSolve, matchKey, stripGpTail, getDiscoveryUserMarkedKeys, delay, dataDir } from '#src/util.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
+import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref } from '#src/gamerpower.js';
+import { fetchFGFPosts, filterFor as filterFgfFor, cleanTitle as fgfClean } from '#src/freegamefindings.js';
 
 // GOG 2FA backup-code consumption. Codes are configured comma-separated
 // via GOG_OTP_BACKUP_CODES; used codes are appended to

--- a/src/platforms/humble-bundle.js
+++ b/src/platforms/humble-bundle.js
@@ -1,8 +1,8 @@
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { datetime, notify, log, dataDir, handleSIGINT } from './src/util.js';
-import { launchContext, gotoWithRetry } from './src/browser.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
+import { datetime, notify, log, dataDir, handleSIGINT } from '#src/util.js';
+import { launchContext, gotoWithRetry } from '#src/browser.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
 
 // Watch-only Humble Bundle free-items tracker. No login, no auto-claim —
 // loads humblebundle.com/store/search?priceMax=0 in a real browser

--- a/src/platforms/lenovo-gaming.js
+++ b/src/platforms/lenovo-gaming.js
@@ -23,11 +23,11 @@
 // canonically. Listing-fetch is one HTTP round trip; detail fetches only
 // run for drops that are new or whose schedule we don't have cached.
 
-import { launchContext, gotoWithRetry } from './src/browser.js';
+import { launchContext, gotoWithRetry } from '#src/browser.js';
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { datetime, notify, log, dataDir, handleSIGINT } from './src/util.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
+import { datetime, notify, log, dataDir, handleSIGINT } from '#src/util.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
 
 handleSIGINT();
 log.section(`Lenovo Gaming (v${siteVersion('lenovo-gaming')})`);

--- a/src/platforms/lenovo-gaming.js
+++ b/src/platforms/lenovo-gaming.js
@@ -10,7 +10,7 @@
 //   - restock detected (title contains "(Restocked!)")
 //
 // Pre-drop "1 hour before" / "5 minutes before" notifications come from
-// the engine-side lenovoSchedulerLoop in interactive-login.js, which reads
+// the engine-side lenovoSchedulerLoop in src/panel/panel.js, which reads
 // this same JSON file and wakes at the dynamic per-drop times. The watcher
 // just keeps the file fresh.
 //

--- a/src/platforms/microsoft.js
+++ b/src/platforms/microsoft.js
@@ -1,11 +1,11 @@
 import { devices } from 'patchright';
-import { launchContext, gotoWithRetry } from './src/browser.js';
+import { launchContext, gotoWithRetry } from '#src/browser.js';
 import { authenticator } from 'otplib';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { delay, datetime, prompt, notify, log, dataDir, jsonDb } from './src/util.js';
-import { cfg } from './src/config.js';
-import { describeConfig } from './src/app-config.js';
-import { siteVersion } from './src/sites.js';
+import { delay, datetime, prompt, notify, log, dataDir, jsonDb } from '#src/util.js';
+import { cfg } from '#src/config.js';
+import { describeConfig } from '#src/app-config.js';
+import { siteVersion } from '#src/sites.js';
 
 const BING_REWARDS_URL = 'https://rewards.bing.com';
 const BING_URL = 'https://www.bing.com';

--- a/src/platforms/prime-gaming.js
+++ b/src/platforms/prime-gaming.js
@@ -1,8 +1,8 @@
-import { launchContext, gotoWithRetry } from './src/browser.js';
+import { launchContext, gotoWithRetry } from '#src/browser.js';
 import { authenticator } from 'otplib';
-import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, log } from './src/util.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, confirm, notify, html_game_list, log } from '#src/util.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
 
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'prime-gaming', ...a);
 

--- a/src/platforms/steam.js
+++ b/src/platforms/steam.js
@@ -1,10 +1,10 @@
-import { launchContext, gotoWithRetry } from './src/browser.js';
+import { launchContext, gotoWithRetry } from '#src/browser.js';
 import { writeFileSync } from 'node:fs';
-import { resolve, jsonDb, datetime, filenamify, prompt, notify, html_game_list, log, dataDir, matchKey, stripGpTail, getDiscoveryUserMarkedKeys } from './src/util.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
-import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref } from './src/gamerpower.js';
-import { fetchFGFPosts, filterFor as filterFgfFor, cleanTitle as fgfClean } from './src/freegamefindings.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, notify, html_game_list, log, dataDir, matchKey, stripGpTail, getDiscoveryUserMarkedKeys } from '#src/util.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
+import { fetchGamerPowerGiveaways, filterFor as filterGpFor, resolveGamerPowerHref } from '#src/gamerpower.js';
+import { fetchFGFPosts, filterFor as filterFgfFor, cleanTitle as fgfClean } from '#src/freegamefindings.js';
 
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'steam', ...a);
 

--- a/src/platforms/ubisoft.js
+++ b/src/platforms/ubisoft.js
@@ -1,7 +1,7 @@
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { datetime, notify, log, dataDir, handleSIGINT } from './src/util.js';
-import { cfg } from './src/config.js';
-import { siteVersion } from './src/sites.js';
+import { datetime, notify, log, dataDir, handleSIGINT } from '#src/util.js';
+import { cfg } from '#src/config.js';
+import { siteVersion } from '#src/sites.js';
 
 // Watch-only Ubisoft Connect free-games tracker. No login, no claim — just
 // diffs the current /free-games page against a saved baseline and pushes a

--- a/src/sites.js
+++ b/src/sites.js
@@ -1,6 +1,6 @@
 // Site registry — the single declarative source of truth for every service
 // the engine knows about. Phase 0 of the engine refactor (issue #11): this
-// file holds the data; engine code in interactive-login.js + app-config.js
+// file holds the data; engine code in src/panel/panel.js + app-config.js
 // is migrated commit-by-commit to derive its hand-edited tables from here.
 //
 // Each entry carries everything the engine needs about a service:
@@ -116,7 +116,7 @@ export const SITES = [
     script: platformScript('prime-gaming'),
     claimOrder: 2,
     // Getter so PG_BASE_URL takes effect at access time. Reads on each
-    // cookie-import (interactive-login.js#deriveTargetHost) and each
+    // cookie-import (src/panel/panel.js#deriveTargetHost) and each
     // panel-opened browser-login — both happen long after module load,
     // so this resolves to the live cfg value without a restart.
     get loginUrl() { return `${cfg.pg_base_url}/claims`; },
@@ -239,7 +239,7 @@ export const SITES = [
     // login is needed in the common case. 3.5 slots between epic-games (3)
     // and steam (4) in the claim chain ordering.
     claimOrder: 3.5,
-    // FAB sign-in redirects to Epic's OAuth. Point the interactive-login
+    // FAB sign-in redirects to Epic's OAuth. Point the panel's login
     // target at the free-assets page; an unauthenticated visit surfaces the
     // Sign In control, and an authenticated one lands where the user wants.
     loginUrl: 'https://www.fab.com/limited-time-free',

--- a/src/sites.js
+++ b/src/sites.js
@@ -799,6 +799,40 @@ export function getClaimScriptOrder() {
       : { id: s.id, script: s.script });
 }
 
+// Runner basenames the registry knows: 'gog', 'epic-games', … Entries with
+// script: null (microsoft-mobile) are skipped.
+const RUNNER_NAMES = new Set(
+  SITES.filter(s => s.script).map(s => path.basename(s.script, '.js')),
+);
+
+// Rewrites the command word of one segment, preserving inline env and args:
+//   'node gog.js'  → 'node src/platforms/gog.js'
+//   'steam'        → 'node src/platforms/steam.js'
+//   'echo gog'     → unchanged; the command word is 'echo', not 'gog'
+function normalizeClaimSegment(seg) {
+  const m = /^(\s*(?:\w+=\S*\s+)*)(?:node\s+)?(\S+)([\s\S]*)$/.exec(seg);
+  if (!m) return seg;
+  const [, lead, word, rest] = m;
+  const name = word.replace(/\.js$/, '').replace(/^.*\//, '');
+  // Rewritten: a known runner in any spelling ('gog', 'gog.js', './gog.js',
+  // 'src/platforms/gog.js'), or a bare '<file>.js' — nothing executable sits at
+  // the repo root anymore, so the name can only mean a scraper.
+  // Left alone: 'echo', './x.sh', '/opt/mine/pre.js', 'gogg' (typo, no .js).
+  if (!RUNNER_NAMES.has(name) && !/^[^/]+\.js$/.test(word)) return seg;
+  return `${lead}node ${platformScript(name)}${rest}`;
+}
+
+// CLAIM_CMD / CLAIM_CMD_MANUAL name scrapers by path, so an override written for
+// an older layout breaks on the next move. Resolve each command through the
+// registry instead: 'gog.js; steam.js' runs as
+// 'node src/platforms/gog.js; node src/platforms/steam.js'. A step that isn't a
+// runner ('./x.sh', 'echo done') comes back byte-identical.
+export function normalizeClaimCommand(cmd) {
+  if (typeof cmd !== 'string') return cmd;
+  // Separators are never part of a match, so they survive untouched.
+  return cmd.replace(/[^;&|\n]+/g, seg => normalizeClaimSegment(seg));
+}
+
 // Settings-tab "Active" toggle linking. Each parent entry's linkedWith
 // pointer fans out to a list whose first element is the parent and second
 // element is the linked sub-service — toggling either id flips both. Today

--- a/src/sites.js
+++ b/src/sites.js
@@ -8,8 +8,11 @@
 //   id              stable identifier used in config keys + UI deep links
 //   name            human-readable label shown in cards and notifications
 //   subtitle        optional second-line note rendered under name (Settings)
-//   script          per-service runner ('foo.js') or null for sub-services
-//                   that share their parent's script (microsoft-mobile)
+//   script          per-service runner as a repo-root-relative path, so the
+//                   spawned `node <script>` resolves from the process cwd.
+//                   Always build it with platformScript('foo') rather than
+//                   writing the path by hand. null for sub-services that
+//                   share their parent's script (microsoft-mobile)
 //   loginUrl        page to navigate to for interactive login (null = no
 //                   login flow, e.g. ubisoft watch-only)
 //   browserDir      persistent profile dir; null if no browser is launched
@@ -47,8 +50,28 @@
 // SERVICE_ROWS, …) that read these fields. Until then the new fields are
 // metadata-only and safe to ignore.
 
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { devices } from 'patchright';
 import { cfg } from './config.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// Resolves a runner through the '#platforms/*' alias in package.json, so the
+// directory is declared once and serves both `import` and the spawned
+// `node <script>`. Returns a repo-root-relative path on purpose: the value
+// lands in shell commands, run logs and the CLAIM_CMD docs, where an absolute
+// container path would be noise.
+//
+// Tolerant on input — 'gog', 'gog.js' and even 'gog.js.js' all give
+// 'src/platforms/gog.js', so a call site that spells out the extension can't
+// double it. import.meta.resolve validates the alias, not the target, so a
+// misspelled name still returns a path and surfaces when the runner spawns.
+function platformScript(name) {
+  const file = String(name).replace(/(?:\.js)+$/, '') + '.js';
+  const abs = fileURLToPath(import.meta.resolve(`#platforms/${file}`));
+  return path.relative(REPO_ROOT, abs).split(path.sep).join('/');
+}
 
 // Read the signed-in Microsoft Rewards user via the dashboard's own
 // dapi/me endpoint. page.request inherits the browser context's cookies, so a
@@ -90,7 +113,7 @@ export const SITES = [
     name: 'Prime Gaming',
     version: '2.1',
     subtitle: null,
-    script: 'prime-gaming.js',
+    script: platformScript('prime-gaming'),
     claimOrder: 2,
     // Getter so PG_BASE_URL takes effect at access time. Reads on each
     // cookie-import (interactive-login.js#deriveTargetHost) and each
@@ -162,7 +185,7 @@ export const SITES = [
     name: 'Epic Games',
     version: '2.2',
     subtitle: null,
-    script: 'epic-games.js',
+    script: platformScript('epic-games'),
     claimOrder: 3,
     loginUrl: 'https://www.epicgames.com/id/login?lang=en-US&noHostRedirect=true&redirectUrl=https://store.epicgames.com/en-US/free-games',
     // Sessions tab "open in new tab" target. loginUrl points to the login
@@ -210,7 +233,7 @@ export const SITES = [
     name: 'FAB',
     version: '0.2',
     subtitle: 'Claims the monthly "Limited-Time Free" assets on fab.com (Epic\'s 3D content marketplace) using your existing Epic Games session. Opt-in. Scaffolded — fab.com\'s DOM/selectors may need iteration as Epic updates the store.',
-    script: 'fab.js',
+    script: platformScript('fab'),
     // Runs right after Epic so the shared browser profile already holds a
     // warm Epic session — FAB authenticates via Epic SSO, so no second
     // login is needed in the common case. 3.5 slots between epic-games (3)
@@ -277,7 +300,7 @@ export const SITES = [
     name: 'GOG',
     version: '2.3',
     subtitle: null,
-    script: 'gog.js',
+    script: platformScript('gog'),
     // Runs AFTER Prime Gaming (claimOrder 2) so Prime→GOG cross-store
     // keys discovered on a given run can be redeemed same-day rather
     // than waiting for the next scheduled gog.js. Before v2.8.80 GOG
@@ -390,7 +413,7 @@ export const SITES = [
     name: 'Steam',
     version: '2.1',
     subtitle: null,
-    script: 'steam.js',
+    script: platformScript('steam'),
     claimOrder: 4,
     loginUrl: 'https://store.steampowered.com/login/',
     homeUrl: 'https://store.steampowered.com/',
@@ -444,7 +467,7 @@ export const SITES = [
     name: 'AliExpress',
     version: '2.3',
     subtitle: 'Deprecated by AliExpress — web coin collection is being phased out in favor of the mobile app. Works for some accounts on a degradation curve. See README → Bot detection.',
-    script: 'aliexpress.js',
+    script: platformScript('aliexpress'),
     claimOrder: 5,
     // AliExpress's coin collector only works on the mobile site; desktop just
     // says "install the app". Use a dedicated browser profile so its
@@ -515,7 +538,7 @@ export const SITES = [
     name: 'Microsoft Rewards',
     version: '2.2',
     subtitle: 'Runs both desktop and mobile sessions in one script.',
-    script: 'microsoft.js',
+    script: platformScript('microsoft'),
     claimOrder: 9,
     loginUrl: 'https://rewards.bing.com',
     get browserDir() { return cfg.dir.browser; },
@@ -638,7 +661,7 @@ export const SITES = [
     name: 'Ubisoft Connect',
     version: '2.0',
     subtitle: 'Watch-only: pings you when a new free game appears at store.ubisoft.com/us/free-games. No login, no auto-claim — go grab it manually.',
-    script: 'ubisoft.js',
+    script: platformScript('ubisoft'),
     claimOrder: 6,
     loginUrl: null,
     homeUrl: 'https://store.ubisoft.com/us/free-games',
@@ -658,7 +681,7 @@ export const SITES = [
     name: 'Humble Bundle',
     version: '0.2',
     subtitle: 'Watch-only: pings you when new free items appear at humblebundle.com store. No login, no auto-claim — go grab manually. Scaffolded scratch — selectors and URL paths may need iteration as Humble updates their store layout.',
-    script: 'humble-bundle.js',
+    script: platformScript('humble-bundle'),
     claimOrder: 7,
     loginUrl: null,
     homeUrl: 'https://www.humblebundle.com/store/search?sort=discount&filter=onsale&min=0&max=0',
@@ -678,7 +701,7 @@ export const SITES = [
     name: 'Fanatical',
     version: '0.2',
     subtitle: 'Watch-only: pings you when new free Steam keys appear at fanatical.com/en/free-games-keys. No login, no auto-claim — go grab manually. Scaffolded — Fanatical\'s API endpoint and product shape may need iteration over time.',
-    script: 'fanatical.js',
+    script: platformScript('fanatical'),
     claimOrder: 8,
     loginUrl: null,
     // Fanatical removed the dedicated /en/free-games-keys landing page from
@@ -703,7 +726,7 @@ export const SITES = [
     name: 'Lenovo Gaming Key Drops',
     version: '0.2',
     subtitle: 'Watch-only: tracks scheduled key-drops at gaming.lenovo.com/game-key-drops. Notifies on discovery + 1h before / 5min before / at drop time. Drops are first-come-first-served once they go live, so the script is paired with a per-drop wake scheduler that fires push notifications on time. Auto-claim is a future phase — keys are first-come-first-served and the redemption flow goes through GamesPlanet.',
-    script: 'lenovo-gaming.js',
+    script: platformScript('lenovo-gaming'),
     claimOrder: 10,
     loginUrl: null,
     homeUrl: 'https://gaming.lenovo.com/game-key-drops',

--- a/src/util.js
+++ b/src/util.js
@@ -134,7 +134,7 @@ export const getOrCreateFingerprint = (profileDir, generate) => {
 // foreign-host check. Once present, the lock never clears on its own.
 //
 // We can safely remove these files because the app's runtime mutex
-// (browserBusy in interactive-login.js) prevents two Chromium processes
+// (browserBusy in src/panel/panel.js) prevents two Chromium processes
 // from racing on the same profile dir. Called from launchPersistentContext
 // sites before launch, and from the panel's startup as a clean-room
 // sweep across all known profile dirs. (Fix per feldorn#37, 2026-05-15
@@ -257,7 +257,7 @@ async function _appendDigest(entry) {
   }
   return Promise.resolve();
 }
-// Read-only accessor for interactive-login.js's digest scheduler.
+// Read-only accessor for src/panel/panel.js's digest scheduler.
 // Returns { buffer, lastFlushedAt } or an empty shape if the file
 // doesn't exist yet.
 export function readDigestBuffer() {
@@ -324,7 +324,7 @@ export const notify = (html, opts = {}) => {
   if (level === 'off') return Promise.resolve();
   if (level === 'actions' && kind === 'summary') return Promise.resolve();
   // Digest tier: buffer per-run summaries into a persistent file that
-  // the panel's dedicated digest scheduler (interactive-login.js)
+  // the panel's dedicated digest scheduler (src/panel/panel.js)
   // drains at notify_digest_hour local time each day. Action-kind
   // notifications (captchas, stale sessions, apprise errors, watcher
   // new-items) still fire real-time — the whole point of the digest

--- a/src/util.js
+++ b/src/util.js
@@ -7,7 +7,10 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, unlink
 // pointed data/ at src/data/, writing outside the mounted volume. Resolved
 // once at load; a missing alias throws here rather than at first use.
 const DATA_DIR = fileURLToPath(import.meta.resolve('#dataDir'));
-const ROOT_DIR = fileURLToPath(import.meta.resolve('#rootDir'));
+// #rootDir points at package.json, not the directory: a bare './' target is
+// matched by trailing slash, which Node deprecated (DEP0166) and warns about
+// once per process — including every spawned scraper.
+const ROOT_DIR = path.dirname(fileURLToPath(import.meta.resolve('#rootDir')));
 // explicit object instead of Object.fromEntries since the built-in type would loose the keys, better type: https://dev.to/svehla/typescript-object-fromentries-389c
 export const dataDir = s => path.resolve(DATA_DIR, s);
 // for root-level paths that aren't under data/ (package.json, assets/)

--- a/src/util.js
+++ b/src/util.js
@@ -1,12 +1,17 @@
-// https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, unlinkSync, lstatSync } from 'node:fs';
-// not the same since these will give the absolute paths for this file instead of for the file using them
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+// Both anchors come from the package.json `imports` map rather than from this
+// file's own depth. Resolving them off __dirname only held while util.js sat
+// exactly one level below the root — moving the file would have silently
+// pointed data/ at src/data/, writing outside the mounted volume. Resolved
+// once at load; a missing alias throws here rather than at first use.
+const DATA_DIR = fileURLToPath(import.meta.resolve('#dataDir'));
+const ROOT_DIR = fileURLToPath(import.meta.resolve('#rootDir'));
 // explicit object instead of Object.fromEntries since the built-in type would loose the keys, better type: https://dev.to/svehla/typescript-object-fromentries-389c
-export const dataDir = s => path.resolve(__dirname, '..', 'data', s);
+export const dataDir = s => path.resolve(DATA_DIR, s);
+// for root-level paths that aren't under data/ (package.json, assets/)
+export const rootDir = s => path.resolve(ROOT_DIR, s);
 
 // modified path.resolve to return null if first argument is '0', used to disable screenshots
 export const resolve = (...a) => a.length && a[0] == '0' ? null : path.resolve(...a);

--- a/test/claim-cmd.js
+++ b/test/claim-cmd.js
@@ -1,0 +1,58 @@
+// normalizeClaimCommand — run with `node test/claim-cmd.js`.
+// Covers the shapes a CLAIM_CMD / CLAIM_CMD_MANUAL override shows up in, and
+// the ones that must pass through untouched.
+// util.js first: it reads cfg in its module body while config.js imports it
+// back, so entering the cycle from sites.js hits the TDZ. Same order the panel
+// uses.
+import '#src/util.js';
+import { normalizeClaimCommand } from '#src/sites.js';
+
+const P = 'src/platforms';
+
+const cases = [
+  // overrides written before the scrapers moved
+  ['node gog.js; node steam.js', `node ${P}/gog.js; node ${P}/steam.js`],
+  ['node prime-gaming.js; node epic-games.js; node microsoft.js',
+    `node ${P}/prime-gaming.js; node ${P}/epic-games.js; node ${P}/microsoft.js`],
+  ['node ./gog.js', `node ${P}/gog.js`],
+  // short forms
+  ['gog.js; steam.js', `node ${P}/gog.js; node ${P}/steam.js`],
+  ['gog; steam', `node ${P}/gog.js; node ${P}/steam.js`],
+  ['node gog', `node ${P}/gog.js`],
+  // current spelling stays put
+  [`node ${P}/gog.js`, `node ${P}/gog.js`],
+  // separators, inline env and args survive
+  ['node gog.js && node steam.js', `node ${P}/gog.js && node ${P}/steam.js`],
+  ['node gog.js & node steam.js', `node ${P}/gog.js & node ${P}/steam.js`],
+  ['MS_SKIP_WINDOW=1 node microsoft.js', `MS_SKIP_WINDOW=1 node ${P}/microsoft.js`],
+  ['node gog.js --debug', `node ${P}/gog.js --debug`],
+  // not ours to touch
+  ['echo gog', 'echo gog'],
+  ['echo "starting gog.js"', 'echo "starting gog.js"'],
+  ['node /opt/mine/pre.js', 'node /opt/mine/pre.js'],
+  ['bash -c "node gog.js"', 'bash -c "node gog.js"'],
+  ['curl -s https://example.com/hook', 'curl -s https://example.com/hook'],
+  ['', ''],
+];
+
+let failed = 0;
+for (const [input, want] of cases) {
+  const got = normalizeClaimCommand(input);
+  if (got === want) {
+    console.log(`ok    ${JSON.stringify(input)}`);
+  } else {
+    failed++;
+    console.log(`FAIL  ${JSON.stringify(input)}\n        got  ${JSON.stringify(got)}\n        want ${JSON.stringify(want)}`);
+  }
+}
+
+// Rewriting twice must land in the same place — the panel logs the result, and
+// a second pass over its own output shouldn't drift.
+const twice = normalizeClaimCommand(normalizeClaimCommand('gog; node steam.js'));
+if (twice !== `node ${P}/gog.js; node ${P}/steam.js`) {
+  failed++;
+  console.log(`FAIL  not idempotent: ${JSON.stringify(twice)}`);
+}
+
+console.log(`\n${failed ? `${failed} failed` : `all ${cases.length + 1} passed`}`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Closing out the folder-structure plan from discussions/132.

- 11 claim scrapers moved out of the repo root into `src/platforms/`
- `interactive-login.js` → `src/panel/panel.js` (the name stopped matching the
  file a long time ago — it's the panel server + scheduler)
- Added subpath aliases in `package.json`: `#src/*`, `#platforms/*`, plus
  `#dataDir` / `#rootDir` as path anchors, so imports and path helpers stop
  counting `../` and survive the next move
- `CLAIM_CMD` / `CLAIM_CMD_MANUAL` resolve runner names through the registry
  now, so the move doesn't silently break existing overrides — `gog`, `gog.js`,
  `node gog.js` and full paths all land on the current location, and anything
  that isn't a runner runs as written. `test/claim-cmd.js` covers the cases

Pure moves otherwise. Two things worth flagging: the registry now builds runner
paths with `platformScript()` instead of hardcoding them, and the Microsoft run
guard was matching the literal `node microsoft.js` — it matches on the basename
now, which the move would have broken.