### PR TITLE
refactor(paths): extract path anchors into src/paths.js

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,25 @@
 
 The engine routes everything through `src/sites.js` (the registry) plus a per-site runner script. To add a new claim/watch site, two files change: a registry entry and a `src/platforms/<id>.js` runner.
 
+Paths come from `src/paths.js` — `ROOT_DIR`, `DATA_DIR`, `platformFile()`, and
+the `dataDir()` / `rootDir()` join helpers, which `src/util.js` re-exports and
+most files import from there. Never rebuild a directory from a file's own depth.
+
+`paths.js` holds anchors only — locations that derive from an alias in
+`package.json`. A filename is not an anchor: your watcher state is
+`dataDir('<id>-watch.json')` in your own runner, your claim DB is
+`jsonDb('<id>.json')`, `config.json` is `CONFIG_FILE_PATH` in `src/app-config.js`.
+Add to `paths.js` only when the anchor itself is missing, never to register a
+file — it imports nothing local, so anything can import it without hitting the
+`config.js` ↔ `util.js` cycle.
+
 ### 1. Register it in `src/sites.js`
 
 Append an entry to the `SITES` array. Required fields:
 
 | Field | Notes |
 |---|---|
-| `id` | stable identifier (lowercase, hyphenated) — used in config keys, deep links, claim DB filename |
+| `id` | stable identifier (lowercase, hyphenated) — used in config keys, deep links, claim DB filename. Stick to `a-z A-Z 0-9 -`: the id becomes a filename and reaches shell commands and `CLAIM_CMD`, so anything else is asking for quoting trouble |
 | `name` | human-readable label shown in cards and notifications |
 | `script` | `platformScript('foo')` — resolves through the `#platforms/*` alias and returns a repo-root-relative path. The extension is optional: `'foo'`, `'foo.js'` and `'foo.js.js'` all yield `src/platforms/foo.js`. `null` for sub-services that share a parent's script |
 | `loginUrl` | page to navigate to for interactive login; `null` for no-login services (watchers) |

--- a/src/app-config.js
+++ b/src/app-config.js
@@ -13,16 +13,15 @@
 
 import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { SITES } from './sites.js';
+// dataDir() from paths.js, not from its util.js re-export: importing util.js
+// here closes the cycle app-config.js → util.js → config.js → app-config.js.
+// util.js reads cfg.login_timeout at module scope, so whichever file the cycle
+// re-enters second gets cfg in the TDZ and the process dies at boot with
+// "Cannot access 'cfg' before initialization". paths.js imports nothing local.
+import { dataDir } from './paths.js';
 
-// Compute the data-dir path directly instead of importing dataDir from util.js.
-// util.js itself imports cfg from config.js (for top-level enquirer setup),
-// and config.js is now our caller — importing dataDir from util.js here
-// recreates the cycle and it lands in TDZ when we need it. Resolving the alias
-// directly gives the same anchor with no import, and without depending on how
-// deep this file sits.
-const CONFIG_FILE = path.resolve(fileURLToPath(import.meta.resolve('#dataDir')), 'config.json');
+const CONFIG_FILE = dataDir('config.json');
 
 const toBool = v => v === '1' || v === 'true' || v === true;
 // EG_MOBILE is inverted in the original: absent or truthy → true, only '0'/'false' → false.

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,0 +1,49 @@
+// Repo path anchors, resolved once from the package.json `imports` map.
+//
+// Leaf module on purpose: it imports nothing local, so anyone can pull from it
+// without joining a cycle. That matters here — config.js ↔ util.js already
+// form one, and app-config.js sits on the sites.js → config.js side of it, so
+// neither could reach these anchors through util.js.
+//
+// Anchoring on the aliases instead of each file's own depth means a file can
+// move without silently repointing data/ at its new parent.
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// #rootDir targets package.json rather than the directory: a bare './' target
+// matches by trailing slash, which Node deprecated (DEP0166) and warns about
+// once per process — including every spawned scraper.
+export const ROOT_DIR = path.dirname(fileURLToPath(import.meta.resolve('#rootDir')));
+export const DATA_DIR = fileURLToPath(import.meta.resolve('#dataDir'));
+
+// The join helpers live here, not in util.js, so a module on the config.js ↔
+// util.js cycle can build a path in the same shape as everyone else —
+// app-config.js is the case today. util.js re-exports both, so the ~12 existing
+// call sites keep importing them from there.
+export const dataDir = s => path.resolve(DATA_DIR, s);
+// for root-level paths that aren't under data/ (package.json, assets/)
+export const rootDir = s => path.resolve(ROOT_DIR, s);
+
+// Individual files under data/ are not declared here. Everything above derives
+// from an alias in package.json; a filename derives from whichever module owns
+// the file — config.json is exported as CONFIG_FILE_PATH by app-config.js,
+// watcher state by each watcher, the claim DBs by jsonDb(), all via dataDir().
+// Declaring one here makes paths.js the catalog of every data/ filename, with
+// no rule left for what stays out.
+
+// Runner names double as filenames and reach shell commands, so they are held
+// to the same charset CONTRIBUTING gives for a service id.
+export const RUNNER_NAME_RE = /^[A-Za-z0-9-]+$/;
+
+// No PLATFORMS_DIR constant: '#platforms/*' carries the star because it also
+// serves static imports, and no specifier resolves to the bare directory —
+// a trailing slash is what DEP0166 deprecates. Resolving per file keeps the
+// alias as the single source for the location.
+//
+// The name goes inside a specifier, which is parsed as a URL, so it is
+// charset-checked first: an unchecked '#' or '?' truncates the path silently
+// ('a#b.js' would resolve to 'a').
+export function platformFile(name) {
+  if (!RUNNER_NAME_RE.test(name)) throw new Error(`paths: invalid runner name '${name}'`);
+  return fileURLToPath(import.meta.resolve(`#platforms/${name}.js`));
+}

--- a/src/sites.js
+++ b/src/sites.js
@@ -51,11 +51,9 @@
 // metadata-only and safe to ignore.
 
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { devices } from 'patchright';
 import { cfg } from './config.js';
-
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+import { ROOT_DIR, RUNNER_NAME_RE, platformFile } from './paths.js';
 
 // Resolves a runner through the '#platforms/*' alias in package.json, so the
 // directory is declared once and serves both `import` and the spawned
@@ -67,10 +65,11 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..
 // 'src/platforms/gog.js', so a call site that spells out the extension can't
 // double it. import.meta.resolve validates the alias, not the target, so a
 // misspelled name still returns a path and surfaces when the runner spawns.
+//
+// platformFile() throws on anything outside 'A-Z' 'a-z' '0-9' '-' — see paths.js for why.
 function platformScript(name) {
-  const file = String(name).replace(/(?:\.js)+$/, '') + '.js';
-  const abs = fileURLToPath(import.meta.resolve(`#platforms/${file}`));
-  return path.relative(REPO_ROOT, abs).split(path.sep).join('/');
+  const file = String(name).replace(/(?:\.js)+$/, '');
+  return path.relative(ROOT_DIR, platformFile(file)).split(path.sep).join('/');
 }
 
 // Read the signed-in Microsoft Rewards user via the dashboard's own
@@ -885,6 +884,10 @@ function normalizeClaimSegment(seg) {
   // the repo root anymore, so the name can only mean a scraper.
   // Left alone: 'echo', './x.sh', '/opt/mine/pre.js', 'gogg' (typo, no .js).
   if (!RUNNER_NAMES.has(name) && !/^[^/]+\.js$/.test(word)) return seg;
+  // Registry ids are A-Za-z0-9- (see paths.js), so 'my_tool.js' and 'a#b.js'
+  // are somebody else's script. Pass them through for the shell to report
+  // instead of letting platformFile() throw in the middle of a run.
+  if (!RUNNER_NAME_RE.test(name)) return seg;
   return `${lead}node ${platformScript(name)}${rest}`;
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,20 +1,9 @@
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, unlinkSync, lstatSync } from 'node:fs';
-// Both anchors come from the package.json `imports` map rather than from this
-// file's own depth. Resolving them off __dirname only held while util.js sat
-// exactly one level below the root — moving the file would have silently
-// pointed data/ at src/data/, writing outside the mounted volume. Resolved
-// once at load; a missing alias throws here rather than at first use.
-const DATA_DIR = fileURLToPath(import.meta.resolve('#dataDir'));
-// #rootDir points at package.json, not the directory: a bare './' target is
-// matched by trailing slash, which Node deprecated (DEP0166) and warns about
-// once per process — including every spawned scraper.
-const ROOT_DIR = path.dirname(fileURLToPath(import.meta.resolve('#rootDir')));
-// explicit object instead of Object.fromEntries since the built-in type would loose the keys, better type: https://dev.to/svehla/typescript-object-fromentries-389c
-export const dataDir = s => path.resolve(DATA_DIR, s);
-// for root-level paths that aren't under data/ (package.json, assets/)
-export const rootDir = s => path.resolve(ROOT_DIR, s);
+// Defined in paths.js and re-exported here, which is where the rest of the tree
+// imports them from.
+import { dataDir, rootDir } from './paths.js';
+export { dataDir, rootDir };
 
 // modified path.resolve to return null if first argument is '0', used to disable screenshots
 export const resolve = (...a) => a.length && a[0] == '0' ? null : path.resolve(...a);
@@ -39,7 +28,7 @@ const MODULE_SERVICE_TAG = (() => {
 // never throws, never blocks the notification.
 function writeJournalEntry(entry) {
   try {
-    const journalFile = path.resolve(DATA_DIR, 'notifications-log.json');
+    const journalFile = dataDir('notifications-log.json');
     let data;
     try {
       const raw = existsSync(journalFile) ? readFileSync(journalFile, 'utf8') : '';


### PR DESCRIPTION
ROOT_DIR/DATA_DIR lived in util.js, which reads cfg at module scope. app-config.js sits on the sites.js -> config.js side of the config.js <-> util.js cycle, so it resolved '#dataDir' by hand instead. paths.js imports nothing local and is reachable from either side.

It exports both anchors, dataDir()/rootDir() (re-exported by util.js, where the existing call sites keep importing them), and platformFile(), which charset-checks the name before it enters the specifier: specifiers parse as URLs, so an unchecked '#' truncates the path ('a#b.js' -> 'a'). normalizeClaimSegment() screens CLAIM_CMD words against the same regex, so a foreign 'my_tool.js' reaches the shell instead of throwing mid-run.

Filenames under data/ stay out: paths.js holds only what derives from a package.json alias. writeJournalEntry() reached for DATA_DIR directly and now goes through dataDir() -- its journal write is wrapped in a swallowing try/catch, so the dangling reference would have silently disabled the notifications journal rather than failing.