### PR TITLE
feat(ms): collect additional points in new ui

### DIFF
--- a/src/platforms/microsoft.js
+++ b/src/platforms/microsoft.js
@@ -9,6 +9,7 @@ import { siteVersion } from '#src/sites.js';
 
 const BING_REWARDS_URL = 'https://rewards.bing.com';
 const BING_URL = 'https://www.bing.com';
+const BING_DEFAULT_SEARCH_ENGINE_URL = 'https://www.bing.com?FORM=CHROMN&PC=U316&q=';
 
 // Retry policy shared by this site's top-level navigations. isRecoverableMsNavError
 // is a hoisted function declaration, so referencing it here is fine.
@@ -960,7 +961,7 @@ async function clickNewUiActivityCards(page) {
   const pages = [
     { url: BING_REWARDS_URL + '/dashboard', label: 'dailyset',      ariaLabel: 'Daily set',       selector: '#dailyset a:not([href$="/earn"]):not(:has(.bg-statusSuccessRewardsBg))' },
     { url: BING_REWARDS_URL + '/earn',      label: 'exploreonbing', ariaLabel: 'Explore on Bing', selector: '#exploreonbing a:not(:has(.grayscale)):not(:has(.bg-statusSuccessRewardsBg))' },
-  ];
+      ];
   let attempted = 0, clicked = 0, errors = 0, savedDiag = false;
   for (const { url, label, ariaLabel, selector } of pages) {
     if (page.isClosed()) break;
@@ -1162,6 +1163,12 @@ async function executeBingSearch(page, searchTerm, preEnterMs) {
   }
 }
 
+async function executeBingSearchAsDefaultSearchEngine(page, searchTerm) {
+  await page.goto(`${BING_DEFAULT_SEARCH_ENGINE_URL}${encodeURIComponent(searchTerm)}`, { waitUntil: 'load' });
+
+  await page.locator('#b_results').waitFor({ timeout: 60000 });
+}
+
 // A "browser closed" / "context closed" Playwright error means the
 // underlying Chromium process is gone (user closed the window in VNC,
 // container OOM-killed it, etc.). No amount of retry will recover —
@@ -1271,7 +1278,7 @@ process.on('SIGINT', async () => {
 const _jitter = () => Math.floor(Math.random() * 5) - 2; // -2..+2
 const desktopSearchCount = Math.max(1, (cfg.ms_desktop_search_count || 35) + _jitter());
 const mobileSearchCount  = Math.max(1, (cfg.ms_mobile_search_count  || 25) + _jitter());
-const searchTerms = await buildSearchList(desktopSearchCount + mobileSearchCount);
+const searchTerms = await buildSearchList(1 + desktopSearchCount + mobileSearchCount);
 
 // Per-run point balance history used by the web panel's Stats tab.
 const msDb = await jsonDb('microsoft-rewards.json', { runs: [] });
@@ -1331,7 +1338,8 @@ log.section('Desktop');
       await clickEveryPendingActivityCard(page);
       await claimPendingBonusPoints(page);
       await claimReadyToClaimCard(page);
-      await executeBingSearches(page, searchTerms.slice(0, desktopSearchCount), { startingBalance: before });
+      await executeBingSearchAsDefaultSearchEngine(page, searchTerms[0]);
+      await executeBingSearches(page, searchTerms.slice(1, desktopSearchCount), { startingBalance: before });
       after = await readPointsBalance(page);
       if (after != null) log.status('Points after', after + (before != null ? ` (+${after - before})` : ''));
       log.summary({

--- a/src/platforms/microsoft.js
+++ b/src/platforms/microsoft.js
@@ -959,9 +959,10 @@ async function clickNewUiActivityCards(page) {
   // trips MS's "unusual activity" gate. Class-based lookup is
   // locale-portable. (JLMael's #110 follow-up, 2026-07-07.)
   const pages = [
-    { url: BING_REWARDS_URL + '/dashboard', label: 'dailyset',      ariaLabel: 'Daily set',       selector: '#dailyset a:not([href$="/earn"]):not(:has(.bg-statusSuccessRewardsBg))' },
-    { url: BING_REWARDS_URL + '/earn',      label: 'exploreonbing', ariaLabel: 'Explore on Bing', selector: '#exploreonbing a:not(:has(.grayscale)):not(:has(.bg-statusSuccessRewardsBg))' },
-      ];
+    { url: BING_REWARDS_URL + '/dashboard', label: 'dailyset',       ariaLabel: 'Daily set',       selector: '#dailyset a:not([href$="/earn"]):not(:has(.bg-statusSuccessRewardsBg))' },
+    { url: BING_REWARDS_URL + '/earn',      label: 'exploreonbing',  ariaLabel: 'Explore on Bing', selector: '#exploreonbing a:not(:has(.grayscale)):not(:has(.bg-statusSuccessRewardsBg))' },
+    { url: BING_REWARDS_URL + '/earn',      label: 'moreactivities', ariaLabel: 'Keep earning',    selector: '#moreactivities p.text-metadata.leading-none.text-statusInformativeTintFg' },
+  ];
   let attempted = 0, clicked = 0, errors = 0, savedDiag = false;
   for (const { url, label, ariaLabel, selector } of pages) {
     if (page.isClosed()) break;


### PR DESCRIPTION
This pr adds 2 new ways of earning points in the new ui.

**feat(ms): complete monthly "Default search bonus" challenge**
<img width="334" height="510" alt="image" src="https://github.com/user-attachments/assets/1f046475-d79f-4b93-93b4-3a4f8b8659c8" />

Completes the challenge by executing 1 search directly using the URL `https://www.bing.com?FORM=CHROMN&PC=U316&q=`. This URL is the same one used when you configure Bing as your default search engine in your browser and directly search for something in the URL bar.

**feat(ms): collect additional points from the "Keep earning" section**
<img width="1247" height="345" alt="image" src="https://github.com/user-attachments/assets/5bee0556-e7d0-4180-836f-4b8d1062e63c" />

Sometimes the "Keep earning" section has additional cards that give you points by clicking them (like the daily set). Added an additional selector that selects all cards in the "Keep earning" section with the small point tag in the bottom left corner.